### PR TITLE
Refactor SwitcherContextBase to use instance instead of reflection (#…

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can also use environment variables using the standard notation ${VALUE:DEFAU
 
 ```
 #required
-switcher.context -> Feature class that extends SwitcherContext
+switcher.context -> Feature class that extends SwitcherContext/SwitcherContextBase
 switcher.url -> Switcher-API URL
 switcher.apikey -> Switcher-API key generated for the application/component
 switcher.component -> Application/component name

--- a/src/main/java/com/github/switcherapi/client/ContextBuilder.java
+++ b/src/main/java/com/github/switcherapi/client/ContextBuilder.java
@@ -53,11 +53,11 @@ public class ContextBuilder {
 	}
 
 	/**
-	 * @param contextLocation Feature class that extends SwitcherContext
+	 * @param context Feature class that extends SwitcherContext
 	 * @return ContextBuilder
 	 */
-	public ContextBuilder contextLocation(String contextLocation) {
-		switcherProperties.setValue(ContextKey.CONTEXT_LOCATION, contextLocation);
+	public ContextBuilder context(String context) {
+		switcherProperties.setValue(ContextKey.CONTEXT_LOCATION, context);
 		return this;
 	}
 

--- a/src/main/java/com/github/switcherapi/client/SwitcherConfig.java
+++ b/src/main/java/com/github/switcherapi/client/SwitcherConfig.java
@@ -2,7 +2,6 @@ package com.github.switcherapi.client;
 
 abstract class SwitcherConfig {
 
-	protected String contextLocation;
 	protected String url;
 	protected String apikey;
 	protected String domain;
@@ -30,9 +29,14 @@ abstract class SwitcherConfig {
 	 */
 	protected abstract void configureClient();
 
-	public void setContextLocation(String contextLocation) {
-		this.contextLocation = contextLocation;
-	}
+	/**
+	 * Initialize the Switcher Client using a context properties file.<br>
+	 * - Load context properties file {@link SwitcherContextBase#loadProperties(String)}<br>
+	 * - Initialize client {@link SwitcherContextBase#initializeClient()}<br>
+	 *
+	 * @param contextFile path to the context file
+	 */
+	protected abstract void configureClient(String contextFile);
 
 	public void setUrl(String url) {
 		this.url = url;

--- a/src/main/java/com/github/switcherapi/client/SwitcherContext.java
+++ b/src/main/java/com/github/switcherapi/client/SwitcherContext.java
@@ -33,7 +33,9 @@ public abstract class SwitcherContext extends SwitcherContextBase {
 	 * After loading the properties, it will validate the arguments and load the Switchers in memory.
 	 */
 	public static void loadProperties() {
-		loadProperties("switcherapi");
+		SwitcherContextBase.contextBase = null;
+		SwitcherContextBase.loadProperties("switcherapi");
+		SwitcherContextBase.initializeClient();
 	}
 	
 	/**
@@ -121,5 +123,5 @@ public abstract class SwitcherContext extends SwitcherContextBase {
 	public static void configure(ContextBuilder builder) {
 		SwitcherContextBase.configure(builder);
 	}
-	
+
 }

--- a/src/main/java/com/github/switcherapi/client/SwitcherContextBase.java
+++ b/src/main/java/com/github/switcherapi/client/SwitcherContextBase.java
@@ -65,7 +65,7 @@ import static com.github.switcherapi.client.remote.Constants.DEFAULT_TIMEOUT;
  * // Initialize the Switcher Client using ContextBuilder
  * public void configureClient() {
  *  	Features.configure(ContextBuilder.builder()
- *   		.contextLocation("com.business.config.Features")
+ *   		.context("com.business.config.Features")
  *   		.apiKey("API_KEY")
  *   		.domain("Playground")
  *   		.component("switcher-playground")
@@ -91,6 +91,7 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 	private static ScheduledExecutorService scheduledExecutorService;
 	private static ExecutorService watcherExecutorService;
 	private static SnapshotWatcher watcherSnapshot;
+	protected static SwitcherContextBase contextBase;
 	
 	static {
 		switcherProperties = new SwitcherPropertiesImpl();
@@ -98,8 +99,9 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 
 	@Override
 	protected void configureClient() {
+		setContextBase(this);
 		configure(ContextBuilder.builder(true)
-				.contextLocation(contextLocation)
+				.context(contextBase.getClass().getName())
 				.url(url)
 				.apiKey(apikey)
 				.domain(domain)
@@ -117,19 +119,32 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 				.truststorePath(truststore.getPath())
 				.truststorePassword(truststore.getPassword()));
 
+		switcherProperties.setValue(ContextKey.CONTEXT_LOCATION, contextBase.getClass().getName());
 		initializeClient();
 	}
-	
+
+	@Override
+	protected void configureClient(String contextFile) {
+		setContextBase(this);
+		loadProperties(contextFile);
+
+		switcherProperties.setValue(ContextKey.CONTEXT_LOCATION, contextBase.getClass().getName());
+		initializeClient();
+	}
+
+	private static synchronized void setContextBase(SwitcherContextBase contextBase) {
+		SwitcherContextBase.contextBase = contextBase;
+	}
+
 	/**
 	 * Load properties from the resources' folder, look up for a given context file name (without extension).<br>
-	 * After loading the properties, it will validate the arguments and load the Switchers in memory.
 	 * <p>
-	 * Use this method optionally if you want to load the settings from a customized file name.
+	 * Use this method optionally if you want to load the settings from properties file.<br>
 	 * </p>
 	 *
 	 * Features must inherit {@link SwitcherContextBase}
 	 * <pre>
-	 * // Load from resources/switcherapi-test.properties 
+	 * // Load from resources/switcherapi-test.properties
 	 * Features.loadProperties("switcherapi-test");
 	 * </pre>
 	 * @param contextFilename to load properties from
@@ -137,15 +152,14 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 	public static void loadProperties(String contextFilename) {
 		try (InputStream input = SwitcherContextBase.class
 				.getClassLoader().getResourceAsStream(String.format("%s.properties", contextFilename))) {
-			
+
 			Properties prop = new Properties();
-            prop.load(input);
-            
-            switcherProperties.loadFromProperties(prop);
-    		initializeClient();
-        } catch (IOException io) {
-        	throw new SwitcherContextException(io.getMessage());
-        }
+			prop.load(input);
+
+			switcherProperties.loadFromProperties(prop);
+		} catch (IOException io) {
+			throw new SwitcherContextException(io.getMessage());
+		}
 	}
 	
 	/**
@@ -202,17 +216,29 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 	 * It will ensure that only properly annotated Switchers can be used.
 	 */
 	private static void validateSwitcherKeys() {
-		try {
-			switcherKeys = new HashSet<>();
-			
-			final Class<?> clazz = Class.forName(contextStr(ContextKey.CONTEXT_LOCATION));
-			for (Field field : clazz.getFields()) {
-				if (field.isAnnotationPresent(SwitcherKey.class)) {
-					switcherKeys.add(field.getName());
-				}
+		if (Objects.nonNull(contextBase)) {
+			registerSwitcherKey(contextBase.getClass().getFields());
+		} else {
+			try {
+				final Class<?> clazz = Class.forName(contextStr(ContextKey.CONTEXT_LOCATION));
+				registerSwitcherKey(clazz.getFields());
+			} catch(ClassNotFoundException e){
+				throw new SwitcherContextException(e.getMessage());
 			}
-		} catch (ClassNotFoundException e) {
-			throw new SwitcherContextException(e.getMessage());
+		}
+	}
+
+	/**
+	 * Register Switcher Keys based on the annotation {@link SwitcherKey}
+	 *
+	 * @param fields to be registered
+	 */
+	private static void registerSwitcherKey(Field[] fields) {
+		switcherKeys = new HashSet<>();
+		for (Field field : fields) {
+			if (field.isAnnotationPresent(SwitcherKey.class)) {
+				switcherKeys.add(field.getName());
+			}
 		}
 	}
 	

--- a/src/main/java/com/github/switcherapi/client/remote/ClientWS.java
+++ b/src/main/java/com/github/switcherapi/client/remote/ClientWS.java
@@ -20,7 +20,7 @@ public interface ClientWS {
 	 * Returns the token to access all available endpoints
 	 */
 	String AUTH_URL = "%s/criteria/auth";
-
+	
 	/**
 	 * Returns the verification configured for a specific switcher (key)
 	 */
@@ -30,64 +30,64 @@ public interface ClientWS {
 	 * Returns the whole domain structure
 	 */
 	String SNAPSHOT_URL = "%s/graphql";
-
+	
 	/**
 	 * Returns { status: true } if snapshot is updated
 	 */
 	String SNAPSHOT_VERSION_CHECK = "%s/criteria/snapshot_check/%s";
-
+	
 	/**
 	 * Return { status: 200 } if alive
 	 */
 	String CHECK_URL = "%s/check";
-
+	
 	/**
 	 * Returns array of switcher keys not found
 	 */
 	String CHECK_SWITCHERS = "%s/criteria/switchers_check";
-
+	
 	/**
 	 * Returns the verification configured for a specific switcher (key)
-	 *
+	 * 
 	 * @param switcher store all necessary input to access the criteria
 	 * @param token Access token
 	 * @return the execution based on the configured switcher
 	 */
-	CriteriaResponse executeCriteriaService(final Switcher switcher, final String token);
-
+	CriteriaResponse executeCriteria(final Switcher switcher, final String token);
+	
 	/**
 	 * Returns the token to access all available endpoints
-	 *
+	 * 
 	 * @return token and expiration date
 	 */
 	Optional<AuthResponse> auth();
-
+	
 	/**
 	 * Returns the whole domain structure which will be stored into a snapshot file
-	 *
+	 * 
 	 * @param token Access token
 	 * @return domain structure
 	 */
 	Snapshot resolveSnapshot(final String token);
-
+	
 	/**
 	 * Returns { status: true } if snapshot is updated
-	 *
+	 * 
 	 * @param version current domain version
 	 * @param token Access token
 	 * @return status: true if domain is updated
 	 */
 	SnapshotVersionResponse checkSnapshotVersion(final long version, final String token);
-
+	
 	/**
 	 * Returns an empty array of not_found if all switchers passed are properly configured.
-	 *
+	 * 
 	 * @param switchers to be validated
 	 * @param token Access token
 	 * @return array of Switchers Key not found/configured
 	 */
 	SwitchersCheck checkSwitchers(final Set<String> switchers, final String token);
-
+	
 	/**
 	 * @return Check whether API is remotely available or not
 	 */

--- a/src/main/java/com/github/switcherapi/client/remote/ClientWSImpl.java
+++ b/src/main/java/com/github/switcherapi/client/remote/ClientWSImpl.java
@@ -48,7 +48,7 @@ public class ClientWSImpl implements ClientWS {
 	}
 
 	@Override
-	public CriteriaResponse executeCriteriaService(final Switcher switcher, final String token) {
+	public CriteriaResponse executeCriteria(final Switcher switcher, final String token) {
 		final String url = switcherProperties.getValue(ContextKey.URL);
 		final WebTarget myResource = client.target(String.format(CRITERIA_URL, url))
 				.queryParam(Switcher.KEY, switcher.getSwitcherKey())

--- a/src/main/java/com/github/switcherapi/client/service/remote/ClientRemoteService.java
+++ b/src/main/java/com/github/switcherapi/client/service/remote/ClientRemoteService.java
@@ -47,7 +47,7 @@ public class ClientRemoteService implements ClientRemote {
 		try {
 			this.auth(tokenStatus);
 
-			return this.clientWs.executeCriteriaService(switcher,
+			return this.clientWs.executeCriteria(switcher,
 					Optional.of(this.authResponse).orElseGet(AuthResponse::new).getToken());
 		} catch (final SwitcherRemoteException e) {
 			if (tokenStatus != TokenStatus.SILENT) {

--- a/src/test/java/com/github/switcherapi/client/SwitcherConfigNativeTest.java
+++ b/src/test/java/com/github/switcherapi/client/SwitcherConfigNativeTest.java
@@ -1,0 +1,52 @@
+package com.github.switcherapi.client;
+
+import com.github.switcherapi.SwitchersBase;
+import com.github.switcherapi.fixture.MockWebServerHelper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SwitcherConfigNativeTest extends MockWebServerHelper {
+
+	@BeforeAll
+	static void setup() throws IOException {
+		MockWebServerHelper.setupMockServer();
+	}
+
+	@AfterAll
+	static void tearDown() throws IOException {
+		MockWebServerHelper.tearDownMockServer();
+	}
+
+	@Test
+	void shouldUseNativeContext() {
+		SwitchersBase context = buildSwitcherClientConfigMinimal(new SwitchersBase(), String.format("http://localhost:%s", mockBackEnd.getPort()));
+		context.configureClient();
+
+		givenResponse(generateMockAuth(10));
+		givenResponse(generateCriteriaResponse("true", false));
+
+		assertTrue(SwitchersBase.getSwitcher(SwitchersBase.USECASE11).isItOn());
+	}
+
+	@Test
+	void shouldUseNativeContextFromProperties() {
+		SwitchersBase context = new SwitchersBase();
+		context.configureClient("switcherapi-native");
+
+		assertTrue(SwitchersBase.getSwitcher(SwitchersBase.USECASE11).isItOn());
+	}
+
+	private <T extends SwitcherConfig> T buildSwitcherClientConfigMinimal(T classConfig, String url) {
+		classConfig.setUrl(url);
+		classConfig.setApikey("[API-KEY]");
+		classConfig.setDomain("domain");
+		classConfig.setComponent("component");
+		return classConfig;
+	}
+
+}

--- a/src/test/java/com/github/switcherapi/client/SwitcherConfigTest.java
+++ b/src/test/java/com/github/switcherapi/client/SwitcherConfigTest.java
@@ -48,7 +48,6 @@ class SwitcherConfigTest {
 		truststore.setPath(null);
 		truststore.setPassword(null);
 
-		classConfig.setContextLocation(SwitchersBase.class.getName());
 		classConfig.setUrl("http://localhost:3000");
 		classConfig.setApikey("[API-KEY]");
 		classConfig.setComponent(component);
@@ -68,7 +67,6 @@ class SwitcherConfigTest {
 		SwitcherConfig.SnapshotConfig snapshot = new SwitcherConfig.SnapshotConfig();
 		snapshot.setLocation(SNAPSHOTS_LOCAL);
 
-		classConfig.setContextLocation(SwitchersBase.class.getName());
 		classConfig.setEnvironment("fixture1");
 		classConfig.setLocal(true);
 		classConfig.setSnapshot(snapshot);

--- a/src/test/java/com/github/switcherapi/client/SwitcherContextBuilderTest.java
+++ b/src/test/java/com/github/switcherapi/client/SwitcherContextBuilderTest.java
@@ -21,7 +21,7 @@ class SwitcherContextBuilderTest {
 	void shouldReturnSuccess() {
 		//given
 		configure(ContextBuilder.builder(true)
-				.contextLocation(SwitchersBase.class.getCanonicalName())
+				.context(SwitchersBase.class.getCanonicalName())
 				.url("http://localhost:3000")
 				.apiKey("API_KEY")
 				.domain("switcher-domain")
@@ -41,7 +41,7 @@ class SwitcherContextBuilderTest {
 	void shouldReturnError_snapshotNotLoaded() {
 		//given
 		configure(ContextBuilder.builder(true)
-				.contextLocation(SwitchersBase.class.getCanonicalName())
+				.context(SwitchersBase.class.getCanonicalName())
 				.url("http://localhost:3000")
 				.apiKey("API_KEY")
 				.domain("switcher-domain")
@@ -59,7 +59,7 @@ class SwitcherContextBuilderTest {
 	void shouldThrowError_wrongContextKeyTypeUsage() {
 		//given
 		configure(ContextBuilder.builder(true)
-				.contextLocation(SwitchersBase.class.getCanonicalName())
+				.context(SwitchersBase.class.getCanonicalName())
 				.domain("switcher-domain")
 				.snapshotLocation(SNAPSHOTS_LOCAL)
 				.local(true));

--- a/src/test/java/com/github/switcherapi/client/SwitcherContextRemoteExecutorTest.java
+++ b/src/test/java/com/github/switcherapi/client/SwitcherContextRemoteExecutorTest.java
@@ -35,7 +35,7 @@ class SwitcherContextRemoteExecutorTest extends MockWebServerHelper {
 
 		//given
 		SwitchersBase.configure(ContextBuilder.builder(true)
-				.contextLocation(SwitchersBase.class.getCanonicalName())
+				.context(SwitchersBase.class.getCanonicalName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.apiKey("API_KEY")
 				.domain("switcher-domain")
@@ -61,7 +61,7 @@ class SwitcherContextRemoteExecutorTest extends MockWebServerHelper {
 
 		//given
 		SwitchersBase.configure(ContextBuilder.builder(true)
-				.contextLocation(SwitchersBase.class.getCanonicalName())
+				.context(SwitchersBase.class.getCanonicalName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.apiKey("API_KEY")
 				.domain("switcher-domain")

--- a/src/test/java/com/github/switcherapi/client/SwitcherContextTest.java
+++ b/src/test/java/com/github/switcherapi/client/SwitcherContextTest.java
@@ -40,7 +40,7 @@ class SwitcherContextTest {
 	
 	@Test
 	void shouldThrowError_noContext() {
-		Switchers.configure(ContextBuilder.builder().contextLocation(null));
+		Switchers.configure(ContextBuilder.builder().context(null));
 		
 		Exception ex = assertThrows(SwitcherContextException.class,
 				Switchers::initializeClient);

--- a/src/test/java/com/github/switcherapi/client/SwitcherSnapshotAutoUpdateTest.java
+++ b/src/test/java/com/github/switcherapi/client/SwitcherSnapshotAutoUpdateTest.java
@@ -88,7 +88,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 
 		//that
 		Switchers.configure(ContextBuilder.builder(true)
-				.contextLocation(Switchers.class.getCanonicalName())
+				.context(Switchers.class.getCanonicalName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.apiKey("[API_KEY]")
 				.snapshotLocation(SNAPSHOTS_LOCAL)
@@ -113,7 +113,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 
 		//that
 		Switchers.configure(ContextBuilder.builder(true)
-				.contextLocation(Switchers.class.getCanonicalName())
+				.context(Switchers.class.getCanonicalName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.apiKey("[API_KEY]")
 				.domain("Test")
@@ -140,7 +140,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 
 		//that
 		Switchers.configure(ContextBuilder.builder(true)
-				.contextLocation(Switchers.class.getCanonicalName())
+				.context(Switchers.class.getCanonicalName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.apiKey("[API_KEY]")
 				.snapshotLocation(SNAPSHOTS_LOCAL)
@@ -168,7 +168,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 
 		//that
 		Switchers.configure(ContextBuilder.builder(true)
-				.contextLocation(Switchers.class.getCanonicalName())
+				.context(Switchers.class.getCanonicalName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.apiKey("[API_KEY]")
 				.environment("generated_mock_default_5")
@@ -193,7 +193,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 
 		//that
 		Switchers.configure(ContextBuilder.builder(true)
-				.contextLocation(Switchers.class.getCanonicalName())
+				.context(Switchers.class.getCanonicalName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.apiKey("[API_KEY]")
 				.environment("generated_mock_default_6")
@@ -224,7 +224,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 
 		//that
 		Switchers.configure(ContextBuilder.builder(true)
-				.contextLocation(Switchers.class.getCanonicalName())
+				.context(Switchers.class.getCanonicalName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.apiKey("[API_KEY]")
 				.environment("generated_mock_default_6")

--- a/src/test/java/com/github/switcherapi/client/service/local/SwitcherLocalServiceTest.java
+++ b/src/test/java/com/github/switcherapi/client/service/local/SwitcherLocalServiceTest.java
@@ -37,7 +37,7 @@ class SwitcherLocalServiceTest {
 	static void init() {
 		executorService = Executors.newSingleThreadExecutor();
 		SwitchersBase.configure(ContextBuilder.builder()
-				.contextLocation("com.github.switcherapi.SwitchersBase")
+				.context("com.github.switcherapi.SwitchersBase")
 				.snapshotLocation(SNAPSHOTS_LOCAL)
 				.environment("default")
 				.local(true));

--- a/src/test/java/com/github/switcherapi/client/utils/SnapshotWatcherErrorTest.java
+++ b/src/test/java/com/github/switcherapi/client/utils/SnapshotWatcherErrorTest.java
@@ -14,7 +14,7 @@ class SnapshotWatcherErrorTest {
 	void shouldNotWatchSnapshotWhenRemote() {
 		//given
 		SwitchersBase.configure(ContextBuilder.builder(true)
-			.contextLocation(SwitchersBase.class.getCanonicalName())
+			.context(SwitchersBase.class.getCanonicalName())
 			.url("https://api.switcherapi.com")
 			.apiKey("[API_KEY]")
 			.domain("Test")

--- a/src/test/java/com/github/switcherapi/client/utils/SnapshotWatcherTest.java
+++ b/src/test/java/com/github/switcherapi/client/utils/SnapshotWatcherTest.java
@@ -38,7 +38,7 @@ class SnapshotWatcherTest {
 		generateFixture();
 		
 		SwitchersBase.configure(ContextBuilder.builder()
-			.contextLocation(SwitchersBase.class.getCanonicalName())
+			.context(SwitchersBase.class.getCanonicalName())
 			.environment("generated_watcher_default")
 			.snapshotLocation(SNAPSHOTS_LOCAL)
 			.local(true));

--- a/src/test/java/com/github/switcherapi/client/utils/SnapshotWatcherWorkerTest.java
+++ b/src/test/java/com/github/switcherapi/client/utils/SnapshotWatcherWorkerTest.java
@@ -19,7 +19,7 @@ class SnapshotWatcherWorkerTest {
 	@BeforeAll
 	static void setupContext() {
 		SwitchersBase.configure(ContextBuilder.builder()
-			.contextLocation(SwitchersBase.class.getCanonicalName())
+			.context(SwitchersBase.class.getCanonicalName())
 			.snapshotLocation(SNAPSHOTS_LOCAL)
 			.environment("default")
 			.silentMode(null)

--- a/src/test/java/com/github/switcherapi/fixture/MockWebServerHelper.java
+++ b/src/test/java/com/github/switcherapi/fixture/MockWebServerHelper.java
@@ -109,7 +109,7 @@ public class MockWebServerHelper {
     }
 
     /**
-     * @see ClientWSImpl#executeCriteriaService(Switcher, String)
+     * @see ClientWSImpl#executeCriteria(Switcher, String)
      *
      * @param result returned by the criteria execution
      * @param reason if you want to display along with the result
@@ -124,7 +124,7 @@ public class MockWebServerHelper {
     }
 
     /**
-     * @see ClientWSImpl#executeCriteriaService(Switcher, String)
+     * @see ClientWSImpl#executeCriteria(Switcher, String)
      *
      * @param result returned by the criteria execution
      * @return Generated mock /criteria response
@@ -134,7 +134,7 @@ public class MockWebServerHelper {
     }
 
     /**
-     * @see ClientWSImpl#executeCriteriaService(Switcher, String)
+     * @see ClientWSImpl#executeCriteria(Switcher, String)
      *
      * @param result returned by the criteria execution
      * @param reason returned by the criteria execution
@@ -155,7 +155,7 @@ public class MockWebServerHelper {
     }
 
     /**
-     * @see ClientWSImpl#executeCriteriaService(Switcher, String)
+     * @see ClientWSImpl#executeCriteria(Switcher, String)
      *
      * @param metadata returned by the criteria execution
      * @return Generated mock /criteria response

--- a/src/test/java/com/github/switcherapi/playground/ClientPlayground.java
+++ b/src/test/java/com/github/switcherapi/playground/ClientPlayground.java
@@ -19,7 +19,7 @@ public class ClientPlayground {
 	
 	public static void test() {
 		configure(ContextBuilder.builder()
-				.contextLocation(Features.class.getCanonicalName())
+				.context(Features.class.getCanonicalName())
 				.url("https://api.switcherapi.com")
 				.apiKey("[API_KEY]")
 				.domain("Playground")

--- a/src/test/resources/switcherapi-native.properties
+++ b/src/test/resources/switcherapi-native.properties
@@ -1,0 +1,9 @@
+switcher.url=http://localhost:3000
+switcher.apikey=[API_KEY]
+switcher.component=switcher-client
+switcher.environment=fixture1
+switcher.domain=switcher-domain
+
+#optional
+switcher.local=true
+switcher.snapshot.location=./src/test/resources/snapshot


### PR DESCRIPTION
…328)

* Refactor SwitcherContextBase to use instance instead of reflection

* Fix possible thread race when setting up context instance

* Fixes code smell