### PR TITLE
Added switcher.check context configuration to validate Switchers during start

### DIFF
--- a/.github/workflows/master-2.yml
+++ b/.github/workflows/master-2.yml
@@ -1,10 +1,10 @@
-name: Master CI v1
+name: Master CI v2
 
 on:
   push:
-    branches: [master]
+    branches: [master-2]
   pull_request:
-    branches: [master]
+    branches: [master-2]
 
 jobs:
   build-scan:
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['8', '11', '17', '21']
+        java: ['11', '17', '21']
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ switcher.domain -> Domain name
 #optional
 switcher.environment -> Environment name
 switcher.local -> true/false When local, it will only use a local snapshot
+switcher.check -> true/false When true, it will check Switcher Keys
 switcher.relay.restrict -> true/false When true, it will check snapshot relay status
 switcher.snapshot.location -> Folder from where snapshots will be saved/read
 switcher.snapshot.auto -> true/false Automated lookup for snapshot when initializing the client
@@ -312,6 +313,16 @@ In case something is missing, this operation will throw an exception pointing ou
 void testSwitchers() {
 	assertDoesNotThrow(() -> MyAppFeatures.checkSwitchers());
 }
+```
+
+Alternatively, you can also set the Switcher Context configuration to check during the client initialization.
+
+```java
+MyAppFeatures.configure(ContextBuilder.builder()
+    ...
+    .checkSwitchers(true));
+
+MyAppFeatures.initializeClient();
 ```
 
 #### SwitcherTest annotation - Requires JUnit 5 Jupiter

--- a/src/main/java/com/github/switcherapi/client/ContextBuilder.java
+++ b/src/main/java/com/github/switcherapi/client/ContextBuilder.java
@@ -183,6 +183,15 @@ public class ContextBuilder {
 	}
 
 	/**
+	 * @param checkSwitchers true/false When true, it will check switcher keys
+	 * @return ContextBuilder
+	 */
+	public ContextBuilder checkSwitchers(boolean checkSwitchers) {
+		switcherProperties.setValue(ContextKey.CHECK_SWITCHERS, checkSwitchers);
+		return this;
+	}
+
+	/**
 	 * @param restrictRelay true/false When true, it will check snapshot relay status
 	 * @return ContextBuilder
 	 */

--- a/src/main/java/com/github/switcherapi/client/SwitcherConfig.java
+++ b/src/main/java/com/github/switcherapi/client/SwitcherConfig.java
@@ -11,14 +11,17 @@ abstract class SwitcherConfig {
 	protected String environment;
 
 	protected boolean local;
+	protected boolean check;
 	protected String silent;
 	protected Integer timeout;
 	protected Integer regexTimeout;
 	protected Integer poolSize;
+	protected RelayConfig relay;
 	protected SnapshotConfig snapshot;
 	protected TruststoreConfig truststore;
 
 	SwitcherConfig() {
+		this.relay = new RelayConfig();
 		this.snapshot = new SnapshotConfig();
 		this.truststore = new TruststoreConfig();
 	}
@@ -35,9 +38,14 @@ abstract class SwitcherConfig {
 		setComponent(properties.getValue(ContextKey.COMPONENT));
 		setEnvironment(properties.getValue(ContextKey.ENVIRONMENT));
 		setLocal(properties.getBoolean(ContextKey.LOCAL_MODE));
+		setCheck(properties.getBoolean(ContextKey.CHECK_SWITCHERS));
 		setSilent(properties.getValue(ContextKey.SILENT_MODE));
 		setTimeout(properties.getInt(ContextKey.TIMEOUT_MS));
 		setPoolSize(properties.getInt(ContextKey.POOL_CONNECTION_SIZE));
+
+		RelayConfig relayConfig = new RelayConfig();
+		relayConfig.setRestrict(properties.getBoolean(ContextKey.RESTRICT_RELAY));
+		setRelay(relayConfig);
 
 		SnapshotConfig snapshotConfig = new SnapshotConfig();
 		snapshotConfig.setLocation(properties.getValue(ContextKey.SNAPSHOT_LOCATION));
@@ -93,6 +101,10 @@ abstract class SwitcherConfig {
 		this.local = local;
 	}
 
+	public void setCheck(boolean check) {
+		this.check = check;
+	}
+
 	public void setSilent(String silent) {
 		this.silent = silent;
 	}
@@ -109,12 +121,27 @@ abstract class SwitcherConfig {
 		this.poolSize = poolSize;
 	}
 
+	public void setRelay(RelayConfig relay) {
+		this.relay = relay;
+	}
 	public void setSnapshot(SnapshotConfig snapshot) {
 		this.snapshot = snapshot;
 	}
 
 	public void setTruststore(TruststoreConfig truststore) {
 		this.truststore = truststore;
+	}
+
+	public static class RelayConfig {
+		private boolean restrict;
+
+		public boolean isRestrict() {
+			return restrict;
+		}
+
+		public void setRestrict(boolean restrict) {
+			this.restrict = restrict;
+		}
 	}
 
 	public static class SnapshotConfig {

--- a/src/main/java/com/github/switcherapi/client/SwitcherContextBase.java
+++ b/src/main/java/com/github/switcherapi/client/SwitcherContextBase.java
@@ -107,6 +107,8 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 				.environment(environment)
 				.component(component)
 				.local(local)
+				.checkSwitchers(check)
+				.restrictRelay(relay.isRestrict())
 				.silentMode(silent)
 				.regexTimeout(regexTimeout)
 				.timeoutMs(timeout)
@@ -181,7 +183,7 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 		validateContext();
 		registerSwitcherKeys();
 		switcherExecutor = buildInstance();
-		
+
 		loadSwitchers();
 		scheduleSnapshotAutoUpdate(contextStr(ContextKey.SNAPSHOT_AUTO_UPDATE_INTERVAL));
 		ContextBuilder.preConfigure(switcherProperties);
@@ -250,8 +252,14 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 	
 	/**
 	 * Load Switcher instances into a map cache
+	 *
+	 * @throws SwitchersValidationException if "switcher.check" is enabled and one or more Switcher Keys are not found
 	 */
-	private static void loadSwitchers() {
+	private static void loadSwitchers() throws SwitchersValidationException {
+		if (contextBol(ContextKey.CHECK_SWITCHERS)) {
+			checkSwitchers();
+		}
+
 		if (Objects.isNull(switchers)) {
 			switchers = new HashMap<>();
 		}
@@ -447,7 +455,7 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 	 * 
 	 * @throws SwitchersValidationException when one or more Switcher Key is not found
 	 */
-	public static void checkSwitchers() {
+	public static void checkSwitchers() throws SwitchersValidationException {
 		switcherExecutor.checkSwitchers(switcherKeys);
 	}
 	

--- a/src/main/java/com/github/switcherapi/client/SwitcherPropertiesImpl.java
+++ b/src/main/java/com/github/switcherapi/client/SwitcherPropertiesImpl.java
@@ -23,6 +23,7 @@ public class SwitcherPropertiesImpl implements SwitcherProperties {
 		setValue(ContextKey.SNAPSHOT_AUTO_LOAD, false);
 		setValue(ContextKey.SNAPSHOT_SKIP_VALIDATION, false);
 		setValue(ContextKey.LOCAL_MODE, false);
+		setValue(ContextKey.CHECK_SWITCHERS, false);
 		setValue(ContextKey.RESTRICT_RELAY, true);
 	}
 
@@ -40,6 +41,7 @@ public class SwitcherPropertiesImpl implements SwitcherProperties {
 		setValue(ContextKey.SNAPSHOT_AUTO_UPDATE_INTERVAL, SwitcherUtils.resolveProperties(ContextKey.SNAPSHOT_AUTO_UPDATE_INTERVAL.getParam(), prop));
 		setValue(ContextKey.SILENT_MODE, SwitcherUtils.resolveProperties(ContextKey.SILENT_MODE.getParam(), prop));
 		setValue(ContextKey.LOCAL_MODE, getBoolDefault(SwitcherUtils.resolveProperties(ContextKey.LOCAL_MODE.getParam(), prop), false));
+		setValue(ContextKey.CHECK_SWITCHERS, getBoolDefault(SwitcherUtils.resolveProperties(ContextKey.CHECK_SWITCHERS.getParam(), prop), false));
 		setValue(ContextKey.RESTRICT_RELAY, getBoolDefault(SwitcherUtils.resolveProperties(ContextKey.RESTRICT_RELAY.getParam(), prop), true));
 		setValue(ContextKey.REGEX_TIMEOUT, getIntDefault(SwitcherUtils.resolveProperties(ContextKey.REGEX_TIMEOUT.getParam(), prop), DEFAULT_REGEX_TIMEOUT));
 		setValue(ContextKey.TRUSTSTORE_PATH, SwitcherUtils.resolveProperties(ContextKey.TRUSTSTORE_PATH.getParam(), prop));

--- a/src/main/java/com/github/switcherapi/client/model/ContextKey.java
+++ b/src/main/java/com/github/switcherapi/client/model/ContextKey.java
@@ -70,6 +70,11 @@ public enum ContextKey {
 	LOCAL_MODE("switcher.local"),
 
 	/**
+	 * (boolean) Defines if client will check the switchers before using them (default is false).
+	 */
+	CHECK_SWITCHERS("switcher.check"),
+
+	/**
 	 * (boolean) Defines if client will trigger local snapshot relay verification (default is true)
 	 */
 	RESTRICT_RELAY("switcher.relay.restrict"),

--- a/src/main/java/com/github/switcherapi/client/remote/dto/SwitchersCheck.java
+++ b/src/main/java/com/github/switcherapi/client/remote/dto/SwitchersCheck.java
@@ -1,10 +1,10 @@
 package com.github.switcherapi.client.remote.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.switcherapi.client.remote.ClientWS;
+
 import java.util.Arrays;
 import java.util.Set;
-
-import com.github.switcherapi.client.remote.ClientWS;
-import com.google.gson.annotations.SerializedName;
 
 /**
  * Request/Response model to use with {@link ClientWS#checkSwitchers(Set, String)}
@@ -22,7 +22,7 @@ public class SwitchersCheck {
 	/**
 	 * Response field
 	 */
-	@SerializedName("not_found")
+	@JsonProperty("not_found")
 	private String[] notFound;
 	
 	public SwitchersCheck() {}

--- a/src/main/java/com/github/switcherapi/client/remote/dto/SwitchersCheck.java
+++ b/src/main/java/com/github/switcherapi/client/remote/dto/SwitchersCheck.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Set;
 
 import com.github.switcherapi.client.remote.ClientWS;
+import com.google.gson.annotations.SerializedName;
 
 /**
  * Request/Response model to use with {@link ClientWS#checkSwitchers(Set, String)}
@@ -21,6 +22,7 @@ public class SwitchersCheck {
 	/**
 	 * Response field
 	 */
+	@SerializedName("not_found")
 	private String[] notFound;
 	
 	public SwitchersCheck() {}

--- a/src/test/java/com/github/switcherapi/client/SwitcherBasicCriteriaResponseTest.java
+++ b/src/test/java/com/github/switcherapi/client/SwitcherBasicCriteriaResponseTest.java
@@ -25,7 +25,6 @@ class SwitcherBasicCriteriaResponseTest extends MockWebServerHelper {
 		MockWebServerHelper.setupMockServer();
 
 		Switchers.loadProperties(); // Load default properties from resources
-		Switchers.initializeClient(); // SwitcherContext requires preload before config override
 		Switchers.configure(ContextBuilder.builder() // Override default properties
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.local(false)

--- a/src/test/java/com/github/switcherapi/client/SwitcherBasicTest.java
+++ b/src/test/java/com/github/switcherapi/client/SwitcherBasicTest.java
@@ -23,7 +23,6 @@ class SwitcherBasicTest extends MockWebServerHelper {
 		MockWebServerHelper.setupMockServer();
 
 		Switchers.loadProperties(); // Load default properties from resources
-		Switchers.initializeClient(); // SwitcherContext requires preload before config override
 		Switchers.configure(ContextBuilder.builder() // Override default properties
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.local(false)

--- a/src/test/java/com/github/switcherapi/client/SwitcherConfigTest.java
+++ b/src/test/java/com/github/switcherapi/client/SwitcherConfigTest.java
@@ -38,6 +38,9 @@ class SwitcherConfigTest {
 
 	private <T extends SwitcherConfig> T buildSwitcherClientConfig(T classConfig, String component,
 																   String domain) {
+		SwitcherConfig.RelayConfig relay = new SwitcherConfig.RelayConfig();
+		relay.setRestrict(false);
+
 		SwitcherConfig.SnapshotConfig snapshot = new SwitcherConfig.SnapshotConfig();
 		snapshot.setLocation(SNAPSHOTS_LOCAL);
 		snapshot.setUpdateInterval(null);
@@ -54,10 +57,12 @@ class SwitcherConfigTest {
 		classConfig.setDomain(domain);
 		classConfig.setEnvironment("fixture1");
 		classConfig.setLocal(true);
+		classConfig.setCheck(false);
 		classConfig.setSilent("5m");
 		classConfig.setTimeout(3000);
 		classConfig.setRegexTimeout(1000);
 		classConfig.setPoolSize(2);
+		classConfig.setRelay(relay);
 		classConfig.setSnapshot(snapshot);
 		classConfig.setTruststore(truststore);
 		return classConfig;

--- a/src/test/java/com/github/switcherapi/client/SwitcherForceResolveTest.java
+++ b/src/test/java/com/github/switcherapi/client/SwitcherForceResolveTest.java
@@ -22,7 +22,6 @@ class SwitcherForceResolveTest extends MockWebServerHelper {
 		MockWebServerHelper.setupMockServer();
 
 		Switchers.loadProperties(); // Load default properties from resources
-		Switchers.initializeClient(); // SwitcherContext requires preload before config override
 		Switchers.configure(ContextBuilder.builder() // Override default properties
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.local(true)

--- a/src/test/java/com/github/switcherapi/fixture/MockWebServerHelper.java
+++ b/src/test/java/com/github/switcherapi/fixture/MockWebServerHelper.java
@@ -180,8 +180,11 @@ public class MockWebServerHelper {
         String jsonResponse = "{ \"not_found\": [%s] }";
 
         MockResponse.Builder builder = new MockResponse.Builder();
-        builder.body(String.format(jsonResponse, String.join("\",\"", switchersNotFound)));
         builder.addHeader("Content-Type", "application/json");
+        builder.body(String.format(jsonResponse, switchersNotFound.stream()
+                .map(s -> "\"" + s + "\"")
+                .collect(java.util.stream.Collectors.joining(","))));
+
         return builder.build();
     }
 

--- a/src/test/java/com/github/switcherapi/fixture/MockWebServerHelper.java
+++ b/src/test/java/com/github/switcherapi/fixture/MockWebServerHelper.java
@@ -2,7 +2,6 @@ package com.github.switcherapi.fixture;
 
 import com.github.switcherapi.client.model.criteria.Data;
 import com.github.switcherapi.client.model.criteria.Snapshot;
-import com.github.switcherapi.client.remote.dto.SwitchersCheck;
 import com.github.switcherapi.client.remote.ClientWSImpl;
 import com.github.switcherapi.client.remote.dto.CriteriaRequest;
 import com.github.switcherapi.client.utils.SnapshotLoader;
@@ -178,13 +177,10 @@ public class MockWebServerHelper {
      * @return Generated mock /criteria/check_switchers
      */
     protected MockResponse generateCheckSwitchersResponse(Set<String> switchersNotFound) {
-        SwitchersCheck switchersCheckNotFound = new SwitchersCheck();
-        switchersCheckNotFound.setNotFound(
-                switchersNotFound.toArray(new String[0]));
+        String jsonResponse = "{ \"not_found\": [%s] }";
 
-        Gson gson = new Gson();
         MockResponse.Builder builder = new MockResponse.Builder();
-        builder.body(gson.toJson(switchersCheckNotFound));
+        builder.body(String.format(jsonResponse, String.join("\",\"", switchersNotFound)));
         builder.addHeader("Content-Type", "application/json");
         return builder.build();
     }

--- a/src/test/resources/switcherapi.properties
+++ b/src/test/resources/switcherapi.properties
@@ -7,6 +7,8 @@ switcher.domain=switcher-domain
 
 #optional
 switcher.local=
+switcher.check=
+switcher.relay.restrict=
 switcher.snapshot.location=
 switcher.snapshot.auto=
 switcher.snapshot.updateinterval=


### PR DESCRIPTION
- New configuration to test switchers during client start-up "switcher.check"
```java
configure(ContextBuilder.builder()
    ...
    .checkSwitchers(true));

initializeClient();
```
- Fixes remote switcher check that was not serializing the response properly