### PR TITLE
Re-introducing Switcher::getLastExecutionResult feature (#349)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ getSwitcher(FEATURE01)
 	.isItOn();
 ```
 
-4. **Accessing the response history**
-Switchers stores the last execution result from a given switcher key/entry.
+4. **Accessing the last SwitcherResult**
+Switchers stores the last execution result, which can be retrieved using the following operation.
 
 ```java
-switcher.getHistoryExecution();
+switcher.getLastExecutionResult();
 ```
 
 5. **Throttling**
@@ -305,7 +305,7 @@ switcher.isItOn(); // Now, it's going to return the result retrieved from the AP
 For more complex scenarios where you need to test features based on specific inputs, you can use test conditions.
 
 ```java
-Switcher switcher = MyAppFeatures.getSwitcher(FEATURE01).checkValue("My value").build();
+Switcher switcher = MyAppFeatures.getSwitcher(FEATURE01).checkValue("My value");
 
 SwitcherBypass.assume(FEATURE01, true).when(StrategyValidator.VALUE, "My value");
 switcher.isItOn(); // 'true'

--- a/src/main/java/com/github/switcherapi/client/model/Switcher.java
+++ b/src/main/java/com/github/switcherapi/client/model/Switcher.java
@@ -13,27 +13,17 @@ import java.util.List;
  *     <li>Switcher execution</li>
  *     <li>Switcher get input/output</li>
  * </ul>
+ *
+ *  For example:
+ *  <pre>
+ *  Switcher switcher = SwitcherContext
+ *  	.getSwitcher(MY_SWITCHER)
+ *  	.remote(true)
+ *  	.throttle(1000)
+ *  	.checkValue("value");
+ * 	</pre>
  */
 public interface Switcher {
-
-	/**
-	 * This method builds the Switcher object.<br>
-	 * Uses to isolate Switcher creation from the execution.<br>
-	 *
-	 * For example:
-	 * <pre>
-	 * Switcher switcher = SwitcherContext
-	 * 	.getSwitcher(MY_SWITCHER)
-	 * 	.remote(true)
-	 * 	.throttle(1000)
-	 * 	.checkValue("value")
-	 * 	.build();
-	 * </pre>
-	 *
-	 * @return instance of SwitcherInterface
-	 * @see SwitcherRequest
-	 */
-	Switcher build();
 
 	/**
 	 * Prepare the Switcher including a list of inputs necessary to run the criteria afterward.
@@ -106,5 +96,12 @@ public interface Switcher {
 	 * @return the entry of the switcher
 	 */
 	List<Entry> getEntry();
+
+	/**
+	 * Get the last execution result of the switcher.
+	 *
+	 * @return the last SwitcherResult, otherwise null if no executions were made
+	 */
+	SwitcherResult getLastExecutionResult();
 
 }

--- a/src/main/java/com/github/switcherapi/client/model/SwitcherRequest.java
+++ b/src/main/java/com/github/switcherapi/client/model/SwitcherRequest.java
@@ -50,11 +50,6 @@ public final class SwitcherRequest extends SwitcherBuilder {
 		this.historyExecution = new HashSet<>();
 		this.entry = new ArrayList<>();
 	}
-
-	@Override
-	public SwitcherRequest build() {
-		return this;
-	}
 	
 	@Override
 	public SwitcherRequest prepareEntry(final List<Entry> entry) {
@@ -134,6 +129,11 @@ public final class SwitcherRequest extends SwitcherBuilder {
 	@Override
 	public List<Entry> getEntry() {
 		return this.entry;
+	}
+
+	@Override
+	public SwitcherResult getLastExecutionResult() {
+		return getFromHistory().orElse(null);
 	}
 
 	public boolean isBypassMetrics() {

--- a/src/test/java/com/github/switcherapi/client/SwitcherBypassTest.java
+++ b/src/test/java/com/github/switcherapi/client/SwitcherBypassTest.java
@@ -119,7 +119,7 @@ class SwitcherBypassTest {
 		SwitcherContext.initializeClient();
 
 		//test
-		Switcher switcher = getSwitcher(USECASE41).checkValue("Value1").build();
+		Switcher switcher = getSwitcher(USECASE41).checkValue("Value1");
 		assertTrue(switcher.isItOn());
 	}
 
@@ -132,10 +132,10 @@ class SwitcherBypassTest {
 		SwitcherContext.initializeClient();
 
 		//test
-		Switcher switcher = getSwitcher(USECASE41).checkValue("Value1").build();
+		Switcher switcher = getSwitcher(USECASE41).checkValue("Value1");
 		assertTrue(switcher.isItOn());
 
-		switcher = getSwitcher(USECASE41).checkValue("Value2").build();
+		switcher = getSwitcher(USECASE41).checkValue("Value2");
 		assertTrue(switcher.isItOn());
 	}
 
@@ -150,7 +150,7 @@ class SwitcherBypassTest {
 		SwitcherContext.initializeClient();
 
 		//test
-		Switcher switcher = getSwitcher(USECASE41).checkValue("Value1").build();
+		Switcher switcher = getSwitcher(USECASE41).checkValue("Value1");
 		assertTrue(switcher.isItOn());
 	}
 
@@ -163,7 +163,7 @@ class SwitcherBypassTest {
 		SwitcherContext.initializeClient();
 
 		//test
-		Switcher switcher = getSwitcher(USECASE41).checkValue("Value1").build();
+		Switcher switcher = getSwitcher(USECASE41).checkValue("Value1");
 		assertFalse(switcher.isItOn());
 	}
 
@@ -251,7 +251,7 @@ class SwitcherBypassTest {
 		SwitcherContext.initializeClient();
 
 		//test
-		Switcher switcher = getSwitcher(USECASE41).checkValue("Value1").build();
+		Switcher switcher = getSwitcher(USECASE41).checkValue("Value1");
 
 		SwitcherBypass.assume(USECASE41, true)
 						.when(StrategyValidator.VALUE, "Value1");
@@ -266,7 +266,7 @@ class SwitcherBypassTest {
 		SwitcherContext.initializeClient();
 
 		//test
-		Switcher switcher = getSwitcher(USECASE41).checkValue("Value2").build();
+		Switcher switcher = getSwitcher(USECASE41).checkValue("Value2");
 
 		SwitcherBypass.assume(USECASE41, true)
 				.when(StrategyValidator.VALUE, "Value1");

--- a/src/test/java/com/github/switcherapi/client/SwitcherLocal1Test.java
+++ b/src/test/java/com/github/switcherapi/client/SwitcherLocal1Test.java
@@ -4,7 +4,10 @@ import com.github.switcherapi.Switchers;
 import com.github.switcherapi.client.exception.SwitcherInvalidNumericFormat;
 import com.github.switcherapi.client.exception.SwitcherInvalidTimeFormat;
 import com.github.switcherapi.client.exception.SwitcherKeyNotFoundException;
-import com.github.switcherapi.client.model.*;
+import com.github.switcherapi.client.model.ContextKey;
+import com.github.switcherapi.client.model.Entry;
+import com.github.switcherapi.client.model.StrategyValidator;
+import com.github.switcherapi.client.model.SwitcherRequest;
 import com.github.switcherapi.fixture.Product;
 import com.google.gson.Gson;
 import org.apache.commons.lang3.StringUtils;
@@ -47,13 +50,23 @@ class SwitcherLocal1Test {
 	@Test
 	void localShouldReturnTrue() {
 		SwitcherRequest switcher = Switchers.getSwitcher(Switchers.USECASE11, true);
+
+		assertNull(switcher.getLastExecutionResult());
 		assertTrue(switcher.isItOn());
+
+		// check result history
+		assertTrue(switcher.getLastExecutionResult().isItOn());
 	}
 	
 	@Test
 	void localShouldReturnFalse() {
 		SwitcherRequest switcher = Switchers.getSwitcher(Switchers.USECASE12);
+
+		assertNull(switcher.getLastExecutionResult());
 		assertFalse(switcher.isItOn());
+
+		// check result history
+		assertFalse(switcher.getLastExecutionResult().isItOn());
 	}
 	
 	@Test

--- a/src/test/java/com/github/switcherapi/client/SwitcherThrottleTest.java
+++ b/src/test/java/com/github/switcherapi/client/SwitcherThrottleTest.java
@@ -58,8 +58,7 @@ class SwitcherThrottleTest extends MockWebServerHelper {
 		//test
 		Switcher switcher = Switchers
 				.getSwitcher(Switchers.REMOTE_KEY)
-				.throttle(1000)
-				.build();
+				.throttle(1000);
 		
 		for (int i = 0; i < 100; i++) {
 			assertTrue(switcher.isItOn());

--- a/src/test/java/com/github/switcherapi/playground/ClientPlayground.java
+++ b/src/test/java/com/github/switcherapi/playground/ClientPlayground.java
@@ -20,8 +20,7 @@ public class ClientPlayground {
 	public static void test() {
 		new Features().configureClient();
 		Switcher switcher = getSwitcher(CLIENT_JAVA_FEATURE)
-				.bypassMetrics()
-				.build();
+				.bypassMetrics();
 
 		scheduler.scheduleAtFixedRate(() -> {
 			try {


### PR DESCRIPTION
This pull request introduces several key improvements to the `Switcher` API, focusing on simplifying its usage and enhancing functionality. The most notable changes include the removal of the `build()` method from `Switcher`, the addition of a `getLastExecutionResult()` method, and updates to the documentation and tests to reflect these changes.

### API Simplification:
* Removed the `build()` method from the `Switcher` interface and related classes, streamlining the process of creating and using `Switcher` objects. [[1]](diffhunk://#diff-cb0f1b33e219d9f5c0d2ad65d6319315ad4ee7bae0975a33d2a436bf78fbc017L16-R26) [[2]](diffhunk://#diff-1c6be0ed57b8a5f62c081e75e46120a95c233ba83386a72c07a753ab564b57c7L54-L58) [[3]](diffhunk://#diff-d17d941c88eb5a602995868a34fe0ccaa8cdf24b3ba035790ebe57ce81861e09L122-R122) [[4]](diffhunk://#diff-d17d941c88eb5a602995868a34fe0ccaa8cdf24b3ba035790ebe57ce81861e09L135-R138) [[5]](diffhunk://#diff-d17d941c88eb5a602995868a34fe0ccaa8cdf24b3ba035790ebe57ce81861e09L153-R153) [[6]](diffhunk://#diff-d17d941c88eb5a602995868a34fe0ccaa8cdf24b3ba035790ebe57ce81861e09L166-R166) [[7]](diffhunk://#diff-d17d941c88eb5a602995868a34fe0ccaa8cdf24b3ba035790ebe57ce81861e09L254-R254) [[8]](diffhunk://#diff-d17d941c88eb5a602995868a34fe0ccaa8cdf24b3ba035790ebe57ce81861e09L269-R269) [[9]](diffhunk://#diff-2336ed564f414fb6972bb5e921740e3a823ced6b39c7cbbb05403e7ad3493d43L61-R61) [[10]](diffhunk://#diff-aab7c1646e327e9406fda03e0567eed1905056d674886bfd423d457bc2d51ae1L23-R23)

### Enhanced Functionality:
* Added a `getLastExecutionResult()` method to the `Switcher` interface and its implementations, enabling retrieval of the last execution result for improved debugging and feature tracking. [[1]](diffhunk://#diff-cb0f1b33e219d9f5c0d2ad65d6319315ad4ee7bae0975a33d2a436bf78fbc017R100-R106) [[2]](diffhunk://#diff-1c6be0ed57b8a5f62c081e75e46120a95c233ba83386a72c07a753ab564b57c7R134-R138) [[3]](diffhunk://#diff-036635eb2ed6467dd6e134ed1a32fb493a973232f79430cf83cedcb2a1c3ea40R53-R69)

### Documentation Updates:
* Updated the `README.md` to replace references to `getHistoryExecution()` with `getLastExecutionResult()` and removed mentions of the `build()` method to align with the new API design. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L193-R197) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L308-R308)

### Test Adjustments:
* Modified test cases across multiple files to remove calls to `build()` and validate the functionality of `getLastExecutionResult()`. [[1]](diffhunk://#diff-d17d941c88eb5a602995868a34fe0ccaa8cdf24b3ba035790ebe57ce81861e09L122-R122) [[2]](diffhunk://#diff-d17d941c88eb5a602995868a34fe0ccaa8cdf24b3ba035790ebe57ce81861e09L135-R138) [[3]](diffhunk://#diff-d17d941c88eb5a602995868a34fe0ccaa8cdf24b3ba035790ebe57ce81861e09L153-R153) [[4]](diffhunk://#diff-d17d941c88eb5a602995868a34fe0ccaa8cdf24b3ba035790ebe57ce81861e09L166-R166) [[5]](diffhunk://#diff-d17d941c88eb5a602995868a34fe0ccaa8cdf24b3ba035790ebe57ce81861e09L254-R254) [[6]](diffhunk://#diff-d17d941c88eb5a602995868a34fe0ccaa8cdf24b3ba035790ebe57ce81861e09L269-R269) [[7]](diffhunk://#diff-036635eb2ed6467dd6e134ed1a32fb493a973232f79430cf83cedcb2a1c3ea40R53-R69) [[8]](diffhunk://#diff-2336ed564f414fb6972bb5e921740e3a823ced6b39c7cbbb05403e7ad3493d43L61-R61)

### Dependency Refinements:
* Adjusted imports in `SwitcherLocal1Test` to reflect the updated API structure.