### PR TITLE
Dropped support for Java 11, bump junit@6.0.0, okhttp@5.2.0

### DIFF
--- a/.github/workflows/master-2.yml
+++ b/.github/workflows/master-2.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['11', '17', '21', '25']
+        java: ['17', '21', '25']
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['11', '17', '21', '25']
+        java: ['17', '21', '25']
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           server-id: central
           server-username: CENTRAL_USERNAME
           server-password: CENTRAL_TOKEN

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Java SDK for Switcher API
 <div align="center">
 
 [![Master CI](https://github.com/switcherapi/switcher-client-java/actions/workflows/master-2.yml/badge.svg)](https://github.com/switcherapi/switcher-client-java/actions/workflows/master-2.yml)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=switcherapi_switcher-client&metric=alert_status)](https://sonarcloud.io/dashboard?id=switcherapi_switcher-client)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=switcherapi_switcher-client&branch=master-2&&metric=alert_status)](https://sonarcloud.io/summary/overall?id=switcherapi_switcher-client&branch=master-2)
 [![Known Vulnerabilities](https://snyk.io/test/github/switcherapi/switcher-client-java/badge.svg?targetFile=pom.xml)](https://snyk.io/test/github/switcherapi/switcher-client-java?targetFile=pom.xml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Maven Central](https://img.shields.io/maven-central/v/com.switcherapi/switcher-client.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/com.switcherapi/switcher-client)
@@ -44,9 +44,9 @@ https://github.com/switcherapi/switcher-api
 </dependency>
 ```
 
-### Compatibility with Jakarta EE 9
-Use SDK v1.x for applications not using Jakarta EE 9.<br>
-Use SDK v2.x for Jakarta EE 9 based applications.
+### Compatibility with Jakarta EE 9 and Java versions
+Use SDK v1.x for applications not using Jakarta EE 9 (requires Java 8+).<br>
+Use SDK v2.x for Jakarta EE 9+ based applications (requires Java 17+).
 
 ## Client Context Properties - SwitcherContext
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<argLine />
@@ -58,10 +58,10 @@
 		<slf4j-api.version>2.0.17</slf4j-api.version>
 
 		<!-- test -->
-		<okhttp.version>5.1.0</okhttp.version>
-		<junit-jupiter.version>5.14.0</junit-jupiter.version>
+		<okhttp.version>5.2.0</okhttp.version>
+		<junit-jupiter.version>6.0.0</junit-jupiter.version>
 		<junit-pioneer.version>2.3.0</junit-pioneer.version>
-		<junit-platform-launcher.version>1.14.0</junit-platform-launcher.version>
+		<junit-platform-launcher.version>6.0.0</junit-platform-launcher.version>
 
 		<!-- Plugins -->
 		<maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
@@ -227,6 +227,12 @@
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
 						<version>${maven-javadoc-plugin.version}</version>
+                        <configuration>
+                            <doclint>all,-missing</doclint>
+                            <additionalJOptions>
+                                <additionalJOption>-Xdoclint:all,-missing</additionalJOption>
+                            </additionalJOptions>
+                        </configuration>
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>

--- a/src/main/java/com/switcherapi/client/test/SwitcherTestExtension.java
+++ b/src/main/java/com/switcherapi/client/test/SwitcherTestExtension.java
@@ -2,11 +2,13 @@ package com.switcherapi.client.test;
 
 import com.switcherapi.client.model.SwitcherResult;
 import org.apache.commons.lang3.ArrayUtils;
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.extension.*;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -29,6 +31,7 @@ class SwitcherTestExtension implements TestTemplateInvocationContextProvider,
 	}
 
 	@Override
+	@NullMarked
 	public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
 		SwitcherTest switcherTest = context.getRequiredTestMethod().getAnnotation(SwitcherTest.class);
 
@@ -58,9 +61,10 @@ class SwitcherTestExtension implements TestTemplateInvocationContextProvider,
 	}
 
 	@Override
+	@NullMarked
 	public void afterTestExecution(ExtensionContext context) {
 		Store store = getStore(context);
-		String[] keys = store.remove(STORE_KEYS, String[].class);
+		String[] keys = Optional.ofNullable(store.remove(STORE_KEYS, String[].class)).orElse(new String[0]);
 
 		if (ArrayUtils.isNotEmpty(keys)) {
 			for (String keyStored : keys) {

--- a/src/main/java/com/switcherapi/client/test/SwitcherTestTemplate.java
+++ b/src/main/java/com/switcherapi/client/test/SwitcherTestTemplate.java
@@ -1,6 +1,7 @@
 package com.switcherapi.client.test;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 
 import java.util.Arrays;
@@ -25,6 +26,7 @@ class SwitcherTestTemplate implements TestTemplateInvocationContext {
     }
 
     @Override
+	@NullMarked
     public String getDisplayName(int invocationIndex) {
         SwitcherTestValue[] switcherTestValues = switcherTest.switchers();
 


### PR DESCRIPTION
This pull request updates the minimum supported Java version for the project from Java 11 to Java 17 and improves compatibility documentation. It also updates test dependencies, enhances Javadoc generation, and makes minor code improvements for null safety in test extension classes.

**Java version and compatibility updates:**
* Updated Java version requirement from 11 to 17 in `pom.xml`, GitHub Actions workflows (`master-2.yml`, `release.yml`), and documentation. The build and release pipelines now only test against Java 17, 21, and 25, and the Maven Central release step uses Java 17. [[1]](diffhunk://#diff-e3ed2e8c0c499d7ae8f818ccb891f6ec657942e17a16c8921de3def382de3cedL37-R37) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L13-R13) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L50-R50) [[4]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L49-R49)
* Improved documentation in `README.md` to clarify SDK compatibility: v1.x requires Java 8+ (non-Jakarta EE 9), v2.x requires Java 17+ (Jakarta EE 9+).

**Dependency and plugin updates:**
* Upgraded test dependencies: `okhttp` to 5.2.0, `junit-jupiter` and `junit-platform-launcher` to 6.0.0 in `pom.xml`.
* Enhanced Maven Javadoc plugin configuration to enable stricter doclint checks and suppress missing documentation warnings.