### PR TITLE
Closes #368 - allow diff Switcher Key constant name

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Instead of using SwitcherContext, which is used to automatically load from the s
 
 ```java
 MyAppFeatures.configure(ContextBuilder.builder()
-		.contextLocation("com.switcherapi.playground.Features")
+		.context(Features.class.getName())
 		.apiKey("API_KEY")
 		.url("https://switcher-api.com")
 		.domain("Playground")
@@ -130,8 +130,15 @@ class MySwitcherClientConfig extends SwitcherContextBase {
 
 ### Defining your features
 
-Create a class that extends SwitcherContext if you are loading the configuration from the switcherapi.properties file.
-Or use SwitcherContextBase to define the configuration using the ContextBuilder or SwitcherConfig.
+Create a class that extends `SwitcherContext` if you are loading the configuration from the switcherapi.properties file.<br>
+Or use `SwitcherContextBase` to define the configuration using the ContextBuilder or SwitcherConfig.
+
+Switcher Keys are defined using the @SwitcherKey annotation and must be public static final String.<br>
+- Public because you will need to access it from other places of your code.
+- Static because you will access it without instantiating the class.
+- Final because the value must not be changed during runtime.
+
+The attribute name can be defined as you want (e.g. FEATURE01, FEATURE_01, myFeatureOne, etc), but the value must be the exact Switcher Key defined in Switcher Management or snapshot files.
 
 ```java
 public class MyAppFeatures extends SwitcherContext {

--- a/src/test/java/com/switcherapi/Switchers.java
+++ b/src/test/java/com/switcherapi/Switchers.java
@@ -142,4 +142,8 @@ public class Switchers extends SwitcherContext {
 
 	@SwitcherKey
 	public static final String NOT_FOUND_KEY = "NOT_FOUND_KEY";
+
+	@SwitcherKey
+	public static final String friendlyFeatureName = "USECASE1";
+
 }

--- a/src/test/java/com/switcherapi/client/SwitcherContextBuilderTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherContextBuilderTest.java
@@ -21,7 +21,7 @@ class SwitcherContextBuilderTest {
 	void shouldReturnSuccess() {
 		//given
 		configure(ContextBuilder.builder(true)
-				.context(SwitchersBase.class.getCanonicalName())
+				.context(SwitchersBase.class.getName())
 				.url("http://localhost:3000")
 				.apiKey("API_KEY")
 				.domain("switcher-domain")
@@ -41,7 +41,7 @@ class SwitcherContextBuilderTest {
 	void shouldReturnError_snapshotNotLoaded() {
 		//given
 		configure(ContextBuilder.builder(true)
-				.context(SwitchersBase.class.getCanonicalName())
+				.context(SwitchersBase.class.getName())
 				.url("http://localhost:3000")
 				.apiKey("API_KEY")
 				.domain("switcher-domain")
@@ -59,7 +59,7 @@ class SwitcherContextBuilderTest {
 	void shouldThrowError_wrongContextKeyTypeUsage() {
 		//given
 		configure(ContextBuilder.builder(true)
-				.context(SwitchersBase.class.getCanonicalName())
+				.context(SwitchersBase.class.getName())
 				.domain("switcher-domain")
 				.snapshotLocation(SNAPSHOTS_LOCAL)
 				.local(true));

--- a/src/test/java/com/switcherapi/client/SwitcherContextRemoteExecutorTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherContextRemoteExecutorTest.java
@@ -36,7 +36,7 @@ class SwitcherContextRemoteExecutorTest extends MockWebServerHelper {
 
 		//given
 		SwitchersBase.configure(ContextBuilder.builder(true)
-				.context(SwitchersBase.class.getCanonicalName())
+				.context(SwitchersBase.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.apiKey("API_KEY")
 				.domain("switcher-domain")
@@ -67,7 +67,7 @@ class SwitcherContextRemoteExecutorTest extends MockWebServerHelper {
 
 		//given
 		SwitchersBase.configure(ContextBuilder.builder(true)
-				.context(SwitchersBase.class.getCanonicalName())
+				.context(SwitchersBase.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.apiKey("API_KEY")
 				.domain("switcher-domain")

--- a/src/test/java/com/switcherapi/client/SwitcherFail3Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherFail3Test.java
@@ -1,0 +1,54 @@
+package com.switcherapi.client;
+
+import com.switcherapi.client.exception.SwitcherContextException;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SwitcherFail3Test {
+
+	private static final String SNAPSHOTS_LOCAL = Paths.get(StringUtils.EMPTY).toAbsolutePath() + "/src/test/resources";
+
+	@Test
+	void shouldNotRegisterSwitcher_nullKey() {
+		//given
+		TestCaseNull.configure(ContextBuilder.builder()
+				.context(TestCaseNull.class.getName())
+				.snapshotLocation(SNAPSHOTS_LOCAL)
+				.local(true));
+
+		//test
+		Exception exception = assertThrows(SwitcherContextException.class, TestCaseNull::initializeClient);
+		assertEquals("Something went wrong: Context has errors - Error retrieving Switcher Key value from field NULL_KEY",
+				exception.getMessage());
+	}
+
+	@Test
+	void shouldNotRegisterSwitcher_emptyKey() {
+		//given
+		TestCaseEmpty.configure(ContextBuilder.builder()
+				.context(TestCaseEmpty.class.getName())
+				.snapshotLocation(SNAPSHOTS_LOCAL)
+				.local(true));
+
+		//test
+		Exception exception = assertThrows(SwitcherContextException.class, TestCaseEmpty::initializeClient);
+		assertEquals("Something went wrong: Context has errors - One or more Switcher Keys are empty",
+				exception.getMessage());
+	}
+
+	static class TestCaseNull extends SwitcherContextBase {
+		@SwitcherKey
+		public static final String NULL_KEY = null;
+	}
+
+	static class TestCaseEmpty extends SwitcherContextBase {
+		@SwitcherKey
+		public static final String EMPTY_KEY = "";
+	}
+
+}

--- a/src/test/java/com/switcherapi/client/SwitcherLocal1Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherLocal1Test.java
@@ -57,6 +57,17 @@ class SwitcherLocal1Test {
 		// check result history
 		assertTrue(switcher.getLastExecutionResult().isItOn());
 	}
+
+	@Test
+	void localShouldReturnTrueUsingFriendlyConstantName() {
+		SwitcherRequest switcher = Switchers.getSwitcher(Switchers.friendlyFeatureName, true);
+
+		assertNull(switcher.getLastExecutionResult());
+		assertTrue(switcher.isItOn());
+
+		// check result history
+		assertTrue(switcher.getLastExecutionResult().isItOn());
+	}
 	
 	@Test
 	void localShouldReturnFalse() {

--- a/src/test/java/com/switcherapi/client/SwitcherSnapshotAutoUpdateTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSnapshotAutoUpdateTest.java
@@ -85,7 +85,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 
 		//that
 		Switchers.configure(ContextBuilder.builder(true)
-				.context(Switchers.class.getCanonicalName())
+				.context(Switchers.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.apiKey("[API_KEY]")
 				.snapshotLocation(SNAPSHOTS_LOCAL)
@@ -110,7 +110,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 
 		//that
 		Switchers.configure(ContextBuilder.builder(true)
-				.context(Switchers.class.getCanonicalName())
+				.context(Switchers.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.apiKey("[API_KEY]")
 				.domain("Test")
@@ -137,7 +137,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 
 		//that
 		Switchers.configure(ContextBuilder.builder(true)
-				.context(Switchers.class.getCanonicalName())
+				.context(Switchers.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.apiKey("[API_KEY]")
 				.snapshotLocation(SNAPSHOTS_LOCAL)
@@ -165,7 +165,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 
 		//that
 		Switchers.configure(ContextBuilder.builder(true)
-				.context(Switchers.class.getCanonicalName())
+				.context(Switchers.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.apiKey("[API_KEY]")
 				.environment("generated_mock_default_5")
@@ -192,7 +192,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 
 		//that
 		Switchers.configure(ContextBuilder.builder(true)
-				.context(Switchers.class.getCanonicalName())
+				.context(Switchers.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.apiKey("[API_KEY]")
 				.environment("generated_mock_default_6")
@@ -227,7 +227,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 
 		//that
 		Switchers.configure(ContextBuilder.builder(true)
-				.context(Switchers.class.getCanonicalName())
+				.context(Switchers.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.apiKey("[API_KEY]")
 				.environment("generated_mock_default_6")

--- a/src/test/java/com/switcherapi/client/service/local/SwitcherLocalServiceTest.java
+++ b/src/test/java/com/switcherapi/client/service/local/SwitcherLocalServiceTest.java
@@ -37,7 +37,7 @@ class SwitcherLocalServiceTest {
 	static void init() {
 		executorService = Executors.newSingleThreadExecutor();
 		SwitchersBase.configure(ContextBuilder.builder()
-				.context("com.switcherapi.SwitchersBase")
+				.context(SwitchersBase.class.getName())
 				.snapshotLocation(SNAPSHOTS_LOCAL)
 				.environment("default")
 				.local(true));

--- a/src/test/java/com/switcherapi/client/utils/SnapshotWatcherContextTest.java
+++ b/src/test/java/com/switcherapi/client/utils/SnapshotWatcherContextTest.java
@@ -19,7 +19,7 @@ class SnapshotWatcherContextTest extends SnapshotTest {
 		generateFixture();
 		
 		SwitchersBase.configure(ContextBuilder.builder(true)
-			.context(SwitchersBase.class.getCanonicalName())
+			.context(SwitchersBase.class.getName())
 			.environment("generated_watcher_default")
 			.snapshotLocation(SNAPSHOTS_LOCAL)
 			.snapshotWatcher(true)

--- a/src/test/java/com/switcherapi/client/utils/SnapshotWatcherErrorTest.java
+++ b/src/test/java/com/switcherapi/client/utils/SnapshotWatcherErrorTest.java
@@ -14,7 +14,7 @@ class SnapshotWatcherErrorTest {
 	void shouldNotWatchSnapshotWhenRemote() {
 		//given
 		SwitchersBase.configure(ContextBuilder.builder(true)
-			.context(SwitchersBase.class.getCanonicalName())
+			.context(SwitchersBase.class.getName())
 			.url("https://api.switcherapi.com")
 			.apiKey("[API_KEY]")
 			.domain("Test")

--- a/src/test/java/com/switcherapi/client/utils/SnapshotWatcherTest.java
+++ b/src/test/java/com/switcherapi/client/utils/SnapshotWatcherTest.java
@@ -22,7 +22,7 @@ class SnapshotWatcherTest extends SnapshotTest {
 		generateFixture();
 		
 		SwitchersBase.configure(ContextBuilder.builder()
-			.context(SwitchersBase.class.getCanonicalName())
+			.context(SwitchersBase.class.getName())
 			.environment("generated_watcher_default")
 			.snapshotLocation(SNAPSHOTS_LOCAL)
 			.local(true));

--- a/src/test/java/com/switcherapi/client/utils/SnapshotWatcherWorkerTest.java
+++ b/src/test/java/com/switcherapi/client/utils/SnapshotWatcherWorkerTest.java
@@ -11,7 +11,7 @@ class SnapshotWatcherWorkerTest extends SnapshotTest {
 	@BeforeAll
 	static void setupContext() {
 		SwitchersBase.configure(ContextBuilder.builder(true)
-			.context(SwitchersBase.class.getCanonicalName())
+			.context(SwitchersBase.class.getName())
 			.snapshotLocation(SNAPSHOTS_LOCAL)
 			.environment("default")
 			.local(true));

--- a/src/test/java/com/switcherapi/playground/Features.java
+++ b/src/test/java/com/switcherapi/playground/Features.java
@@ -12,7 +12,7 @@ public class Features extends SwitcherContextBase {
 	@Override
 	protected void configureClient() {
 		configure(ContextBuilder.builder()
-				.context(Features.class.getCanonicalName())
+				.context(Features.class.getName())
 				.url("https://api.switcherapi.com")
 				.apiKey(System.getenv("switcher.api.key"))
 				.component(System.getenv("switcher.component"))

--- a/src/test/resources/snapshot/fixture1.json
+++ b/src/test/resources/snapshot/fixture1.json
@@ -11,6 +11,14 @@
                 "activated": true,
                 "config": [
                     {
+                      "key": "USECASE1",
+                      "description": "Simple test - Config enabled",
+                      "activated": true,
+                      "components": [
+                            "switcher-client"
+                      ]
+                    },
+                    {
                         "key": "USECASE11",
                         "description": "Simple test - Config enabled",
                         "activated": true,


### PR DESCRIPTION
This pull request improves how Switcher Keys are registered and validated, enhances documentation, and refines test coverage and configuration. The key changes include stricter validation for Switcher Keys to prevent null or empty values, updates to usage documentation, and adjustments to test cases to ensure correct behavior and coverage.

**Switcher Key registration and validation:**

* Switcher Keys are now registered using their actual string values (not field names), and the code throws a `SwitcherContextException` if a key is null or empty, ensuring that only valid keys are used. (`SwitcherContextBase.java`) [[1]](diffhunk://#diff-58fea277cde9b83cbb7929cce8f315b3577b69c0b7f98a82273c85e8a77d616eL246-R261) [[2]](diffhunk://#diff-58fea277cde9b83cbb7929cce8f315b3577b69c0b7f98a82273c85e8a77d616eL541-R557)
* Added new tests to verify that null or empty Switcher Keys cause appropriate exceptions, increasing reliability. (`SwitcherFail3Test.java`)

**Documentation improvements:**

* Updated the `README.md` to clarify how to define Switcher Keys and configure the context, including best practices for key declaration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R97) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L133-R141)

**Test data update:**

* Added a new feature configuration (`USECASE1`) to the test snapshot fixture to support new key usage in tests. (`fixture1.json`)