### PR TITLE
Fixes #371 - throttle using strategy input should cache results

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>com.switcherapi</groupId>
 	<artifactId>switcher-client</artifactId>
 	<packaging>jar</packaging>
-	<version>2.5.0</version>
+	<version>2.5.1</version>
 
 	<name>Switcher Client</name>
 	<description>Switcher Client SDK for working with Switcher API</description>

--- a/src/main/java/com/switcherapi/client/model/SwitcherRequest.java
+++ b/src/main/java/com/switcherapi/client/model/SwitcherRequest.java
@@ -9,7 +9,7 @@ import com.switcherapi.client.test.SwitcherBypass;
 import java.util.*;
 
 /**
- * SwitcherRequest are the entry point to evaluate criteria and return the result.
+ * SwitcherRequest is the entry point to evaluate criteria and return the result.
  * <br>To execute a criteria evaluation, use one of the available methods: {@link #isItOn()}.
  * 
  * @author Roger Floriano (petruki)
@@ -19,12 +19,6 @@ import java.util.*;
  * @see #submit()
  */
 public final class SwitcherRequest extends SwitcherBuilder {
-	
-	public static final String KEY = "key";
-	
-	public static final String SHOW_REASON = "showReason";
-	
-	public static final String BYPASS_METRIC = "bypassMetric";
 
 	private final SwitcherExecutor switcherExecutor;
 	
@@ -150,7 +144,7 @@ public final class SwitcherRequest extends SwitcherBuilder {
 
 	private Optional<SwitcherResult> getFromHistory() {
 		for (SwitcherResult switcherResult : historyExecution) {
-			if (switcherResult.getEntry().equals(getEntry())) {
+			if (switcherResult.getEntry().equals(entry)) {
 				return Optional.of(switcherResult);
 			}
 		}

--- a/src/main/java/com/switcherapi/client/remote/ClientWS.java
+++ b/src/main/java/com/switcherapi/client/remote/ClientWS.java
@@ -41,6 +41,21 @@ public interface ClientWS {
 	 * Returns array of switcher keys not found
 	 */
 	String CHECK_SWITCHERS = "%s/criteria/switchers_check";
+
+	/**
+	 * Constant for query params (Switcher Key)
+	 */
+	String KEY = "key";
+
+	/**
+	 * Constant for query params (Show Reason)
+	 */
+	String SHOW_REASON = "showReason";
+
+	/**
+	 * Constant for query params (Bypass Metric)
+	 */
+	String BYPASS_METRIC = "bypassMetric";
 	
 	/**
 	 * Returns the verification configured for a specific switcher (key)

--- a/src/main/java/com/switcherapi/client/remote/ClientWSImpl.java
+++ b/src/main/java/com/switcherapi/client/remote/ClientWSImpl.java
@@ -1,12 +1,11 @@
 package com.switcherapi.client.remote;
 
+import com.google.gson.Gson;
 import com.switcherapi.client.SwitcherProperties;
 import com.switcherapi.client.exception.SwitcherRemoteException;
 import com.switcherapi.client.model.ContextKey;
-import com.switcherapi.client.model.SwitcherRequest;
 import com.switcherapi.client.model.criteria.Snapshot;
 import com.switcherapi.client.remote.dto.*;
-import com.google.gson.Gson;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -54,9 +53,9 @@ public class ClientWSImpl implements ClientWS {
 		try {
 			final URI uri = new URI(url)
 					.resolve(String.format(CRITERIA_URL, url,
-							SwitcherRequest.KEY, criteriaRequest.getSwitcherKey(),
-							SwitcherRequest.SHOW_REASON, Boolean.TRUE,
-							SwitcherRequest.BYPASS_METRIC, criteriaRequest.isBypassMetric()));
+							KEY, criteriaRequest.getSwitcherKey(),
+							SHOW_REASON, Boolean.TRUE,
+							BYPASS_METRIC, criteriaRequest.isBypassMetric()));
 
 			final HttpResponse<String> response = client.send(HttpRequest.newBuilder()
 					.uri(uri)

--- a/src/main/java/com/switcherapi/client/service/local/SwitcherLocalService.java
+++ b/src/main/java/com/switcherapi/client/service/local/SwitcherLocalService.java
@@ -104,24 +104,24 @@ public class SwitcherLocalService extends SwitcherExecutorImpl {
 	}
 	
 	@Override
-	public SwitcherResult executeCriteria(final SwitcherRequest switcher) {
-		SwitcherUtils.debug(logger, "[Local] request: {}", switcher);
+	public SwitcherResult executeCriteria(final SwitcherRequest switcherRequest) {
+		SwitcherUtils.debug(logger, "[Local] request: {}", switcherRequest);
 
 		SwitcherResult response;
 		try {
-			if (switcher.isRemote()) {
-				response = Mapper.mapFrom(this.clientRemote.executeCriteria(Mapper.mapFrom(switcher)));
+			if (switcherRequest.isRemote()) {
+				response = Mapper.mapFrom(this.clientRemote.executeCriteria(Mapper.mapFrom(switcherRequest)), switcherRequest);
 				SwitcherUtils.debug(logger, "[Remote] response: {}", response);
 			} else {
-				response = this.clientLocal.executeCriteria(switcher, this.domain);
+				response = this.clientLocal.executeCriteria(switcherRequest, this.domain);
 				SwitcherUtils.debug(logger, "[Local] response: {}", response);
 			}
 		} catch (SwitcherKeyNotFoundException e) {
-			if (StringUtils.isBlank(switcher.getDefaultResult())) {
+			if (StringUtils.isBlank(switcherRequest.getDefaultResult())) {
 				throw e;
 			}
 
-			response = SwitcherFactory.buildFromDefault(switcher);
+			response = SwitcherFactory.buildFromDefault(switcherRequest);
 			SwitcherUtils.debug(logger, "[Default] response: {}", response);
 		}
 		

--- a/src/main/java/com/switcherapi/client/service/remote/SwitcherRemoteService.java
+++ b/src/main/java/com/switcherapi/client/service/remote/SwitcherRemoteService.java
@@ -39,17 +39,17 @@ public class SwitcherRemoteService extends SwitcherExecutorImpl {
 	}
 
 	@Override
-	public SwitcherResult executeCriteria(final SwitcherRequest switcher) {
-		SwitcherUtils.debug(logger, "[Remote] request: {}", switcher);
+	public SwitcherResult executeCriteria(final SwitcherRequest switcherRequest) {
+		SwitcherUtils.debug(logger, "[Remote] request: {}", switcherRequest);
 		
 		try {
-			final CriteriaResponse response = this.clientRemote.executeCriteria(Mapper.mapFrom(switcher));
+			final CriteriaResponse response = this.clientRemote.executeCriteria(Mapper.mapFrom(switcherRequest));
 			SwitcherUtils.debug(logger, "[Remote] response: {}", response);
 			
-			return Mapper.mapFrom(response);
+			return Mapper.mapFrom(response, switcherRequest);
 		} catch (final SwitcherRemoteException e) {
 			logger.error("Failed to execute criteria - Cause: {}", e.getMessage(), e.getCause());
-			return tryExecuteLocalCriteria(switcher, e);
+			return tryExecuteLocalCriteria(switcherRequest, e);
 		}
 	}
 

--- a/src/main/java/com/switcherapi/client/utils/Mapper.java
+++ b/src/main/java/com/switcherapi/client/utils/Mapper.java
@@ -17,12 +17,14 @@ public class Mapper {
 		return request;
 	}
 
-	public static SwitcherResult mapFrom(final CriteriaResponse criteriaResponse) {
+	public static SwitcherResult mapFrom(final CriteriaResponse criteriaResponse,
+										 final SwitcherRequest switcherRequest) {
 		SwitcherResult switcherResult = new SwitcherResult();
 		switcherResult.setSwitcherKey(criteriaResponse.getSwitcherKey());
 		switcherResult.setResult(criteriaResponse.getResult());
 		switcherResult.setReason(criteriaResponse.getReason());
 		switcherResult.setMetadata(criteriaResponse.getMetadata());
+		switcherResult.setEntry(switcherRequest.getEntry());
 		return switcherResult;
 	}
 }

--- a/src/test/java/com/switcherapi/client/SwitcherThrottleTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherThrottleTest.java
@@ -48,16 +48,18 @@ class SwitcherThrottleTest extends MockWebServerHelper {
 	void shouldReturnTrue_withThrottle() {
 		Switchers.initializeClient();
 
-		// Throttled call
+		// Initial remote call
 		givenResponse(generateMockAuth(10)); //auth
-		givenResponse(generateCriteriaResponse("true", false)); //criteria
+		givenResponse(generateCriteriaResponse("true", false)); //criteria - sync (cached)
 		
-		// After throttle
-		givenResponse(generateCriteriaResponse("false", false)); //criteria
+		// Throttle period - should use cache
+		givenResponse(generateCriteriaResponse("false", false)); //criteria - async (background)
+		givenResponse(generateCriteriaResponse("false", false)); //criteria - async after 1 sec (background)
 		
 		//test
 		Switcher switcher = Switchers
 				.getSwitcher(Switchers.REMOTE_KEY)
+				.checkValue("value")
 				.throttle(1000);
 		
 		for (int i = 0; i < 100; i++) {

--- a/src/test/java/com/switcherapi/client/remote/ClientRemoteTest.java
+++ b/src/test/java/com/switcherapi/client/remote/ClientRemoteTest.java
@@ -74,13 +74,13 @@ class ClientRemoteTest extends MockWebServerHelper {
         SwitcherProperties switcherProperties = Switchers.getSwitcherProperties();
         SwitcherValidator validatorService = new ValidatorService();
         ClientLocal clientLocal = new ClientLocalService(validatorService);
-        SwitcherRequest switcher = new SwitcherRequest(
+        SwitcherRequest switcherRequest = new SwitcherRequest(
                 "KEY",
                 new SwitcherRemoteService(clientRemote, new SwitcherLocalService(clientRemote, clientLocal, switcherProperties)),
                 switcherProperties);
 
         //test
-        SwitcherResult actual = Mapper.mapFrom(clientRemote.executeCriteria(Mapper.mapFrom(switcher)));
+        SwitcherResult actual = Mapper.mapFrom(clientRemote.executeCriteria(Mapper.mapFrom(switcherRequest)), switcherRequest);
         assertTrue(actual.isItOn());
     }
 


### PR DESCRIPTION
This pull request updates the Switcher Client SDK to version 2.5.1 and fixes throttle feature when using Strategy inputs. The issue was that the mapper wasn't assigning the entries (Strategy inputs) to the copied response object, which caused the cache to have invalid entries.

**Refactoring and code maintenance:**

* Moved query parameter constants (`KEY`, `SHOW_REASON`, `BYPASS_METRIC`) from `SwitcherRequest` to the `ClientWS` interface, and updated all references to use the new location. [[1]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L23-L28) [[2]](diffhunk://#diff-73f7c13916e88a9d34ab504ec707b33a7bfee0360c8ee1277bfdec7dd7ae0fceR45-R59) [[3]](diffhunk://#diff-a39c02177032671f84fcce967ebed4fcf4003052d4f9ca76eb5423f7755d1219L57-R58)
* Updated method and variable names for clarity, such as renaming parameters from `switcher` to `switcherRequest` in service classes and test files. [[1]](diffhunk://#diff-35030a08fd566b7e0eff578ea7b38d28a127ceeea96b08d37e85c870a1f0cb58L107-R124) [[2]](diffhunk://#diff-6b2517a02015d549b9c664ed1fc3290bbbe1c21b2f12304ca7bda615b9829156L42-R52) [[3]](diffhunk://#diff-bf886170e19086ef3f72367630ef7b864fe41e5d14344dab4f52cf60e5d0a992L77-R83)

**Functional improvements:**

* Enhanced the `Mapper.mapFrom` method to correctly set the `entry` field in `SwitcherResult` by passing the `SwitcherRequest` object, ensuring accurate mapping between requests and responses.
* Fixed cache lookup logic in `SwitcherRequest` by referencing the correct `entry` field instead of using a getter, improving cache hit accuracy.