### PR TITLE
Fixes #371 - throttle using strategy input should cache results (#372)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>com.switcherapi</groupId>
 	<artifactId>switcher-client</artifactId>
 	<packaging>jar</packaging>
-	<version>1.9.0</version>
+	<version>1.9.1</version>
 
 	<name>Switcher Client</name>
 	<description>Switcher Client SDK for working with Switcher API</description>

--- a/src/main/java/com/switcherapi/client/model/SwitcherRequest.java
+++ b/src/main/java/com/switcherapi/client/model/SwitcherRequest.java
@@ -9,7 +9,7 @@ import com.switcherapi.client.test.SwitcherBypass;
 import java.util.*;
 
 /**
- * SwitcherRequest are the entry point to evaluate criteria and return the result.
+ * SwitcherRequest is the entry point to evaluate criteria and return the result.
  * <br>To execute a criteria evaluation, use one of the available methods: {@link #isItOn()}.
  * 
  * @author Roger Floriano (petruki)
@@ -19,12 +19,6 @@ import java.util.*;
  * @see #submit()
  */
 public final class SwitcherRequest extends SwitcherBuilder {
-	
-	public static final String KEY = "key";
-	
-	public static final String SHOW_REASON = "showReason";
-	
-	public static final String BYPASS_METRIC = "bypassMetric";
 
 	private final SwitcherExecutor switcherExecutor;
 	
@@ -150,7 +144,7 @@ public final class SwitcherRequest extends SwitcherBuilder {
 
 	private Optional<SwitcherResult> getFromHistory() {
 		for (SwitcherResult switcherResult : historyExecution) {
-			if (switcherResult.getEntry().equals(getEntry())) {
+			if (switcherResult.getEntry().equals(entry)) {
 				return Optional.of(switcherResult);
 			}
 		}

--- a/src/main/java/com/switcherapi/client/remote/ClientWS.java
+++ b/src/main/java/com/switcherapi/client/remote/ClientWS.java
@@ -41,6 +41,21 @@ public interface ClientWS {
 	 * Returns array of switcher keys not found
 	 */
 	String CHECK_SWITCHERS = "%s/criteria/switchers_check";
+
+	/**
+	 * Constant for query params (Switcher Key)
+	 */
+	String KEY = "key";
+
+	/**
+	 * Constant for query params (Show Reason)
+	 */
+	String SHOW_REASON = "showReason";
+
+	/**
+	 * Constant for query params (Bypass Metric)
+	 */
+	String BYPASS_METRIC = "bypassMetric";
 	
 	/**
 	 * Returns the verification configured for a specific switcher (key)

--- a/src/main/java/com/switcherapi/client/remote/ClientWSImpl.java
+++ b/src/main/java/com/switcherapi/client/remote/ClientWSImpl.java
@@ -3,7 +3,6 @@ package com.switcherapi.client.remote;
 import com.switcherapi.client.SwitcherProperties;
 import com.switcherapi.client.exception.SwitcherRemoteException;
 import com.switcherapi.client.model.ContextKey;
-import com.switcherapi.client.model.SwitcherRequest;
 import com.switcherapi.client.model.criteria.Snapshot;
 import com.switcherapi.client.remote.dto.*;
 
@@ -47,9 +46,9 @@ public class ClientWSImpl implements ClientWS {
 	public CriteriaResponse executeCriteria(final CriteriaRequest criteriaRequest, final String token) {
 		final String url = switcherProperties.getValue(ContextKey.URL);
 		final WebTarget myResource = client.target(String.format(CRITERIA_URL, url))
-				.queryParam(SwitcherRequest.KEY, criteriaRequest.getSwitcherKey())
-				.queryParam(SwitcherRequest.SHOW_REASON, Boolean.TRUE)
-				.queryParam(SwitcherRequest.BYPASS_METRIC, criteriaRequest.isBypassMetric());
+				.queryParam(KEY, criteriaRequest.getSwitcherKey())
+				.queryParam(SHOW_REASON, Boolean.TRUE)
+				.queryParam(BYPASS_METRIC, criteriaRequest.isBypassMetric());
 
 		try {
 			final Response response = myResource.request(MediaType.APPLICATION_JSON)

--- a/src/main/java/com/switcherapi/client/service/local/SwitcherLocalService.java
+++ b/src/main/java/com/switcherapi/client/service/local/SwitcherLocalService.java
@@ -104,24 +104,24 @@ public class SwitcherLocalService extends SwitcherExecutorImpl {
 	}
 	
 	@Override
-	public SwitcherResult executeCriteria(final SwitcherRequest switcher) {
-		SwitcherUtils.debug(logger, "[Local] request: {}", switcher);
+	public SwitcherResult executeCriteria(final SwitcherRequest switcherRequest) {
+		SwitcherUtils.debug(logger, "[Local] request: {}", switcherRequest);
 
 		SwitcherResult response;
 		try {
-			if (switcher.isRemote()) {
-				response = Mapper.mapFrom(this.clientRemote.executeCriteria(Mapper.mapFrom(switcher)));
+			if (switcherRequest.isRemote()) {
+				response = Mapper.mapFrom(this.clientRemote.executeCriteria(Mapper.mapFrom(switcherRequest)), switcherRequest);
 				SwitcherUtils.debug(logger, "[Remote] response: {}", response);
 			} else {
-				response = this.clientLocal.executeCriteria(switcher, this.domain);
+				response = this.clientLocal.executeCriteria(switcherRequest, this.domain);
 				SwitcherUtils.debug(logger, "[Local] response: {}", response);
 			}
 		} catch (SwitcherKeyNotFoundException e) {
-			if (StringUtils.isBlank(switcher.getDefaultResult())) {
+			if (StringUtils.isBlank(switcherRequest.getDefaultResult())) {
 				throw e;
 			}
 
-			response = SwitcherFactory.buildFromDefault(switcher);
+			response = SwitcherFactory.buildFromDefault(switcherRequest);
 			SwitcherUtils.debug(logger, "[Default] response: {}", response);
 		}
 		

--- a/src/main/java/com/switcherapi/client/service/remote/SwitcherRemoteService.java
+++ b/src/main/java/com/switcherapi/client/service/remote/SwitcherRemoteService.java
@@ -39,17 +39,17 @@ public class SwitcherRemoteService extends SwitcherExecutorImpl {
 	}
 
 	@Override
-	public SwitcherResult executeCriteria(final SwitcherRequest switcher) {
-		SwitcherUtils.debug(logger, "[Remote] request: {}", switcher);
+	public SwitcherResult executeCriteria(final SwitcherRequest switcherRequest) {
+		SwitcherUtils.debug(logger, "[Remote] request: {}", switcherRequest);
 		
 		try {
-			final CriteriaResponse response = this.clientRemote.executeCriteria(Mapper.mapFrom(switcher));
+			final CriteriaResponse response = this.clientRemote.executeCriteria(Mapper.mapFrom(switcherRequest));
 			SwitcherUtils.debug(logger, "[Remote] response: {}", response);
 			
-			return Mapper.mapFrom(response);
+			return Mapper.mapFrom(response, switcherRequest);
 		} catch (final SwitcherRemoteException e) {
 			logger.error("Failed to execute criteria - Cause: {}", e.getMessage(), e.getCause());
-			return tryExecuteLocalCriteria(switcher, e);
+			return tryExecuteLocalCriteria(switcherRequest, e);
 		}
 	}
 

--- a/src/main/java/com/switcherapi/client/utils/Mapper.java
+++ b/src/main/java/com/switcherapi/client/utils/Mapper.java
@@ -17,12 +17,14 @@ public class Mapper {
 		return request;
 	}
 
-	public static SwitcherResult mapFrom(final CriteriaResponse criteriaResponse) {
+	public static SwitcherResult mapFrom(final CriteriaResponse criteriaResponse,
+										 final SwitcherRequest switcherRequest) {
 		SwitcherResult switcherResult = new SwitcherResult();
 		switcherResult.setSwitcherKey(criteriaResponse.getSwitcherKey());
 		switcherResult.setResult(criteriaResponse.getResult());
 		switcherResult.setReason(criteriaResponse.getReason());
 		switcherResult.setMetadata(criteriaResponse.getMetadata());
+		switcherResult.setEntry(switcherRequest.getEntry());
 		return switcherResult;
 	}
 }

--- a/src/test/java/com/switcherapi/client/SwitcherThrottleTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherThrottleTest.java
@@ -48,16 +48,18 @@ class SwitcherThrottleTest extends MockWebServerHelper {
 	void shouldReturnTrue_withThrottle() {
 		Switchers.initializeClient();
 
-		// Throttled call
+		// Initial remote call
 		givenResponse(generateMockAuth(10)); //auth
-		givenResponse(generateCriteriaResponse("true", false)); //criteria
+		givenResponse(generateCriteriaResponse("true", false)); //criteria - sync (cached)
 		
-		// After throttle
-		givenResponse(generateCriteriaResponse("false", false)); //criteria
+		// Throttle period - should use cache
+		givenResponse(generateCriteriaResponse("false", false)); //criteria - async (background)
+		givenResponse(generateCriteriaResponse("false", false)); //criteria - async after 1 sec (background)
 		
 		//test
 		Switcher switcher = Switchers
 				.getSwitcher(Switchers.REMOTE_KEY)
+				.checkValue("value")
 				.throttle(1000);
 		
 		for (int i = 0; i < 100; i++) {

--- a/src/test/java/com/switcherapi/client/remote/ClientRemoteTest.java
+++ b/src/test/java/com/switcherapi/client/remote/ClientRemoteTest.java
@@ -74,13 +74,13 @@ class ClientRemoteTest extends MockWebServerHelper {
         SwitcherProperties switcherProperties = Switchers.getSwitcherProperties();
         SwitcherValidator validatorService = new ValidatorService();
         ClientLocal clientLocal = new ClientLocalService(validatorService);
-        SwitcherRequest switcher = new SwitcherRequest(
+        SwitcherRequest switcherRequest = new SwitcherRequest(
                 "KEY",
                 new SwitcherRemoteService(clientRemote, new SwitcherLocalService(clientRemote, clientLocal, switcherProperties)),
                 switcherProperties);
 
         //test
-        SwitcherResult actual = Mapper.mapFrom(clientRemote.executeCriteria(Mapper.mapFrom(switcher)));
+        SwitcherResult actual = Mapper.mapFrom(clientRemote.executeCriteria(Mapper.mapFrom(switcherRequest)), switcherRequest);
         assertTrue(actual.isItOn());
     }
 


### PR DESCRIPTION
This pull request updates the Switcher Client SDK to version 2.5.1 and fixes throttle feature when using Strategy inputs. The issue was that the mapper wasn't assigning the entries (Strategy inputs) to the copied response object, which caused the cache to have invalid entries.

**Refactoring and Code Organization:**

* Moved query parameter constants (`KEY`, `SHOW_REASON`, `BYPASS_METRIC`) from `SwitcherRequest` to the `ClientWS` interface, centralizing their definitions and usage. (`[[1]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L23-L28)`, `[[2]](diffhunk://#diff-73f7c13916e88a9d34ab504ec707b33a7bfee0360c8ee1277bfdec7dd7ae0fceR45-R59)`)
* Updated usages in `ClientWSImpl` to reference the constants from `ClientWS` instead of `SwitcherRequest`, ensuring consistency and reducing coupling. (`[src/main/java/com/switcherapi/client/remote/ClientWSImpl.javaL50-R51](diffhunk://#diff-a39c02177032671f84fcce967ebed4fcf4003052d4f9ca76eb5423f7755d1219L50-R51)`)