### PR TITLE
Fixes #374 - prevent invalidate cache reference when async

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>com.switcherapi</groupId>
 	<artifactId>switcher-client</artifactId>
 	<packaging>jar</packaging>
-	<version>2.5.1</version>
+	<version>2.5.2-SNAPSHOT</version>
 
 	<name>Switcher Client</name>
 	<description>Switcher Client SDK for working with Switcher API</description>

--- a/src/main/java/com/switcherapi/client/SwitcherContextBase.java
+++ b/src/main/java/com/switcherapi/client/SwitcherContextBase.java
@@ -398,7 +398,7 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 		
 		final SwitcherRequest switcher = switchers.get(key);
 		if (!keepEntries) {
-			switcher.resetEntry();
+			switcher.flush();
 		}
 		
 		return switcher;

--- a/src/main/java/com/switcherapi/client/model/Entry.java
+++ b/src/main/java/com/switcherapi/client/model/Entry.java
@@ -50,7 +50,7 @@ public class Entry {
 		return String.format("Entry [strategy = %s, input = %s]", 
 				strategy, input);
 	}
-	
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
@@ -69,7 +69,7 @@ public class Entry {
 
 			return this.input.equals(entry.getInput());
 		}
-		return true;
+		return false;
 	}
 
 }

--- a/src/main/java/com/switcherapi/client/model/SwitcherBuilder.java
+++ b/src/main/java/com/switcherapi/client/model/SwitcherBuilder.java
@@ -35,6 +35,16 @@ public abstract class SwitcherBuilder implements Switcher {
 		this.entry = new ArrayList<>();
 		this.delay = 0;
 	}
+
+	/**
+	 * Clear all entries previously added
+	 *
+	 * @return {@link SwitcherBuilder}
+	 */
+	public SwitcherBuilder flush() {
+		this.entry.clear();
+		return this;
+	}
 	
 	/**
 	 * Skip API calls given a delay time
@@ -95,6 +105,7 @@ public abstract class SwitcherBuilder implements Switcher {
 	 */
 	public SwitcherBuilder check(StrategyValidator strategy, String input) {
 		if (StringUtils.isNotBlank(input)) {
+			entry.removeIf(e -> e.getStrategy().equals(strategy.toString()));
 			entry.add(Entry.of(strategy, input));
 		}
 		

--- a/src/main/java/com/switcherapi/client/model/SwitcherRequest.java
+++ b/src/main/java/com/switcherapi/client/model/SwitcherRequest.java
@@ -42,7 +42,6 @@ public final class SwitcherRequest extends SwitcherBuilder {
 		this.switcherExecutor = switcherExecutor;
 		this.switcherKey = switcherKey;
 		this.historyExecution = new HashSet<>();
-		this.entry = new ArrayList<>();
 	}
 	
 	@Override
@@ -54,13 +53,10 @@ public final class SwitcherRequest extends SwitcherBuilder {
 	@Override
 	public SwitcherRequest prepareEntry(final Entry entry, final boolean add) {
 		if (!add) {
-			this.entry.clear();
+			this.flush();
 		}
 
-		if (!this.entry.contains(entry)) {
-			this.entry.add(entry);
-		}
-		
+		this.entry.add(entry);
 		return this;
 	}
 	
@@ -132,10 +128,6 @@ public final class SwitcherRequest extends SwitcherBuilder {
 
 	public boolean isBypassMetrics() {
 		return bypassMetrics;
-	}
-	
-	public void resetEntry() {
-		this.entry = new ArrayList<>();
 	}
 
 	private boolean canUseAsync() {

--- a/src/main/java/com/switcherapi/client/utils/Mapper.java
+++ b/src/main/java/com/switcherapi/client/utils/Mapper.java
@@ -5,6 +5,8 @@ import com.switcherapi.client.model.SwitcherResult;
 import com.switcherapi.client.remote.dto.CriteriaRequest;
 import com.switcherapi.client.remote.dto.CriteriaResponse;
 
+import java.util.List;
+
 public class Mapper {
 
 	private Mapper() {}
@@ -24,7 +26,11 @@ public class Mapper {
 		switcherResult.setResult(criteriaResponse.getResult());
 		switcherResult.setReason(criteriaResponse.getReason());
 		switcherResult.setMetadata(criteriaResponse.getMetadata());
-		switcherResult.setEntry(switcherRequest.getEntry());
+
+		if (!switcherRequest.getEntry().isEmpty()) {
+			switcherResult.setEntry(List.copyOf(switcherRequest.getEntry()));
+		}
+
 		return switcherResult;
 	}
 }

--- a/src/test/java/com/switcherapi/client/SwitcherBasicCriteriaResponseTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherBasicCriteriaResponseTest.java
@@ -1,6 +1,7 @@
 package com.switcherapi.client;
 
 import com.switcherapi.Switchers;
+import com.switcherapi.client.model.SwitcherBuilder;
 import com.switcherapi.client.model.SwitcherRequest;
 import com.switcherapi.client.model.SwitcherResult;
 import com.switcherapi.fixture.MetadataErrorSample;
@@ -81,6 +82,23 @@ class SwitcherBasicCriteriaResponseTest extends MockWebServerHelper {
 
 		assertFalse(response.isItOn());
 		assertEquals("Strategy VALUE_VALIDATION does not agree", response.getReason());
+	}
+
+	@Test
+	void shouldFlushStrategyInputs() {
+		SwitcherBuilder switcherBuilder = Switchers
+				.getSwitcher(Switchers.REMOTE_KEY)
+				.checkValue("value")
+				.checkNumeric("10");
+
+		assertEquals(2, switcherBuilder.getEntry().size());
+
+		//test
+		switcherBuilder
+				.flush()
+				.checkValue("anotherValue");
+
+		assertEquals(1, switcherBuilder.getEntry().size());
 	}
 
 	@Test


### PR DESCRIPTION
This pull request introduces improvements to how strategy inputs are managed in the Switcher client SDK, refactors entry handling for better consistency, and adds new tests to ensure correct behavior when flushing and changing strategy inputs. The changes focus on providing a more robust and predictable API for managing strategy entries and their lifecycle.

**Entry management and API improvements:**

* Added a new `flush()` method to `SwitcherBuilder` that clears all previously added entries, replacing the older `resetEntry()` method and providing a more consistent way to reset strategy inputs. [[1]](diffhunk://#diff-ac0544cec82f9e6e850d4929bf6edf6ba3397237b1bba0012f503cba484971e7R39-R48) [[2]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L137-L140)
* Updated the `check()` method in `SwitcherBuilder` to remove existing entries for the same strategy before adding a new one, ensuring only the latest input for a strategy is considered.
* Refactored entry clearing in `SwitcherRequest` by replacing direct list clearing with the new `flush()` method, standardizing entry management across the codebase. [[1]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L57-L63) [[2]](diffhunk://#diff-58fea277cde9b83cbb7929cce8f315b3577b69c0b7f98a82273c85e8a77d616eL401-R401)

**Result mapping and correctness fixes:**

* Improved the mapping of entries in `Mapper.mapFrom` to ensure that a copy of the current entry list is set in the result only when entries are present, preventing unintended mutations.

**Other minor changes:**

* Fixed a bug in the `Entry.equals` method to correctly return `false` when objects are not equal.

These changes collectively improve the reliability and clarity of strategy input handling in the SDK.