### PR TITLE
 Fixes #374 - prevent invalidate cache reference when async (#375)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>com.switcherapi</groupId>
 	<artifactId>switcher-client</artifactId>
 	<packaging>jar</packaging>
-	<version>1.9.1</version>
+	<version>1.9.2-SNAPSHOT</version>
 
 	<name>Switcher Client</name>
 	<description>Switcher Client SDK for working with Switcher API</description>

--- a/src/main/java/com/switcherapi/client/SwitcherContextBase.java
+++ b/src/main/java/com/switcherapi/client/SwitcherContextBase.java
@@ -399,7 +399,7 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 		
 		final SwitcherRequest switcher = switchers.get(key);
 		if (!keepEntries) {
-			switcher.resetEntry();
+			switcher.flush();
 		}
 		
 		return switcher;

--- a/src/main/java/com/switcherapi/client/model/Entry.java
+++ b/src/main/java/com/switcherapi/client/model/Entry.java
@@ -50,7 +50,7 @@ public class Entry {
 		return String.format("Entry [strategy = %s, input = %s]", 
 				strategy, input);
 	}
-	
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
@@ -71,7 +71,7 @@ public class Entry {
 
 			return this.input.equals(entry.getInput());
 		}
-		return true;
+		return false;
 	}
 
 }

--- a/src/main/java/com/switcherapi/client/model/SwitcherBuilder.java
+++ b/src/main/java/com/switcherapi/client/model/SwitcherBuilder.java
@@ -35,6 +35,16 @@ public abstract class SwitcherBuilder implements Switcher {
 		this.entry = new ArrayList<>();
 		this.delay = 0;
 	}
+
+	/**
+	 * Clear all entries previously added
+	 *
+	 * @return {@link SwitcherBuilder}
+	 */
+	public SwitcherBuilder flush() {
+		this.entry.clear();
+		return this;
+	}
 	
 	/**
 	 * Skip API calls given a delay time
@@ -95,6 +105,7 @@ public abstract class SwitcherBuilder implements Switcher {
 	 */
 	public SwitcherBuilder check(StrategyValidator strategy, String input) {
 		if (StringUtils.isNotBlank(input)) {
+			entry.removeIf(e -> e.getStrategy().equals(strategy.toString()));
 			entry.add(Entry.of(strategy, input));
 		}
 		

--- a/src/main/java/com/switcherapi/client/model/SwitcherRequest.java
+++ b/src/main/java/com/switcherapi/client/model/SwitcherRequest.java
@@ -42,7 +42,6 @@ public final class SwitcherRequest extends SwitcherBuilder {
 		this.switcherExecutor = switcherExecutor;
 		this.switcherKey = switcherKey;
 		this.historyExecution = new HashSet<>();
-		this.entry = new ArrayList<>();
 	}
 	
 	@Override
@@ -54,13 +53,10 @@ public final class SwitcherRequest extends SwitcherBuilder {
 	@Override
 	public SwitcherRequest prepareEntry(final Entry entry, final boolean add) {
 		if (!add) {
-			this.entry.clear();
+			this.flush();
 		}
 
-		if (!this.entry.contains(entry)) {
-			this.entry.add(entry);
-		}
-		
+		this.entry.add(entry);
 		return this;
 	}
 	
@@ -132,10 +128,6 @@ public final class SwitcherRequest extends SwitcherBuilder {
 
 	public boolean isBypassMetrics() {
 		return bypassMetrics;
-	}
-	
-	public void resetEntry() {
-		this.entry = new ArrayList<>();
 	}
 
 	private boolean canUseAsync() {

--- a/src/main/java/com/switcherapi/client/utils/Mapper.java
+++ b/src/main/java/com/switcherapi/client/utils/Mapper.java
@@ -5,6 +5,8 @@ import com.switcherapi.client.model.SwitcherResult;
 import com.switcherapi.client.remote.dto.CriteriaRequest;
 import com.switcherapi.client.remote.dto.CriteriaResponse;
 
+import java.util.List;
+
 public class Mapper {
 
 	private Mapper() {}
@@ -24,7 +26,11 @@ public class Mapper {
 		switcherResult.setResult(criteriaResponse.getResult());
 		switcherResult.setReason(criteriaResponse.getReason());
 		switcherResult.setMetadata(criteriaResponse.getMetadata());
-		switcherResult.setEntry(switcherRequest.getEntry());
+
+		if (!switcherRequest.getEntry().isEmpty()) {
+			switcherResult.setEntry(List.copyOf(switcherRequest.getEntry()));
+		}
+
 		return switcherResult;
 	}
 }

--- a/src/main/java/com/switcherapi/client/utils/Mapper.java
+++ b/src/main/java/com/switcherapi/client/utils/Mapper.java
@@ -5,7 +5,7 @@ import com.switcherapi.client.model.SwitcherResult;
 import com.switcherapi.client.remote.dto.CriteriaRequest;
 import com.switcherapi.client.remote.dto.CriteriaResponse;
 
-import java.util.List;
+import java.util.ArrayList;
 
 public class Mapper {
 
@@ -28,7 +28,7 @@ public class Mapper {
 		switcherResult.setMetadata(criteriaResponse.getMetadata());
 
 		if (!switcherRequest.getEntry().isEmpty()) {
-			switcherResult.setEntry(List.copyOf(switcherRequest.getEntry()));
+			switcherResult.setEntry(new ArrayList<>(switcherRequest.getEntry()));
 		}
 
 		return switcherResult;

--- a/src/test/java/com/switcherapi/client/SwitcherBasicCriteriaResponseTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherBasicCriteriaResponseTest.java
@@ -1,6 +1,7 @@
 package com.switcherapi.client;
 
 import com.switcherapi.Switchers;
+import com.switcherapi.client.model.SwitcherBuilder;
 import com.switcherapi.client.model.SwitcherRequest;
 import com.switcherapi.client.model.SwitcherResult;
 import com.switcherapi.fixture.MetadataErrorSample;
@@ -81,6 +82,23 @@ class SwitcherBasicCriteriaResponseTest extends MockWebServerHelper {
 
 		assertFalse(response.isItOn());
 		assertEquals("Strategy VALUE_VALIDATION does not agree", response.getReason());
+	}
+
+	@Test
+	void shouldFlushStrategyInputs() {
+		SwitcherBuilder switcherBuilder = Switchers
+				.getSwitcher(Switchers.REMOTE_KEY)
+				.checkValue("value")
+				.checkNumeric("10");
+
+		assertEquals(2, switcherBuilder.getEntry().size());
+
+		//test
+		switcherBuilder
+				.flush()
+				.checkValue("anotherValue");
+
+		assertEquals(1, switcherBuilder.getEntry().size());
 	}
 
 	@Test

--- a/src/test/java/com/switcherapi/client/SwitcherThrottleTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherThrottleTest.java
@@ -63,7 +63,7 @@ class SwitcherThrottleTest extends MockWebServerHelper {
 				.checkValue("value")
 				.throttle(1000);
 		
-		for (int i = 0; i < 100; i++) {
+		for (int i = 0; i < 10; i++) {
 			assertTrue(switcher.isItOn());
 		}
 

--- a/src/test/java/com/switcherapi/client/SwitcherThrottleTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherThrottleTest.java
@@ -63,7 +63,7 @@ class SwitcherThrottleTest extends MockWebServerHelper {
 				.checkValue("value")
 				.throttle(1000);
 		
-		for (int i = 0; i < 10; i++) {
+		for (int i = 0; i < 100; i++) {
 			assertTrue(switcher.isItOn());
 		}
 


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the Switcher Client SDK, focusing on entry management, builder usability, and correctness in equality checks. The changes enhance the handling of strategy inputs, ensure proper flushing of entries, and add relevant tests for new behaviors.

**Entry Management and Builder Enhancements:**

* Added a `flush` method to `SwitcherBuilder` to clear all previously added entries, improving usability and enabling easier reset of builder state.
* Updated `SwitcherBuilder.check` to remove existing entries for the same strategy before adding a new one, preventing duplicate strategy inputs.
* Changed logic in `SwitcherRequest` and `SwitcherContextBase` to use `flush` instead of `resetEntry`, standardizing entry clearing across the codebase. [[1]](diffhunk://#diff-58fea277cde9b83cbb7929cce8f315b3577b69c0b7f98a82273c85e8a77d616eL402-R402) [[2]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L57-L63) [[3]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L137-L140)

**Correctness and Bug Fixes:**

* Fixed the `Entry.equals` method to correctly return `false` when objects are not equal, ensuring proper equality checks.