### PR TITLE
feat: changed flush to clean execution history too

### DIFF
--- a/src/main/java/com/switcherapi/client/model/SwitcherBuilder.java
+++ b/src/main/java/com/switcherapi/client/model/SwitcherBuilder.java
@@ -4,9 +4,7 @@ import com.switcherapi.client.SwitcherProperties;
 import com.switcherapi.client.exception.SwitcherContextException;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * Builder class that simplifies how input are programmatically wrapped inside the Switcher.
@@ -17,6 +15,8 @@ import java.util.Objects;
 public abstract class SwitcherBuilder implements Switcher {
 
 	protected final SwitcherProperties properties;
+
+	protected final Map<List<Entry>, SwitcherResult> historyExecution;
 	
 	protected long delay;
 
@@ -32,16 +32,18 @@ public abstract class SwitcherBuilder implements Switcher {
 
 	protected SwitcherBuilder(final SwitcherProperties properties) {
 		this.properties = properties;
+		this.historyExecution = new HashMap<>();
 		this.entry = new ArrayList<>();
 		this.delay = 0;
 	}
 
 	/**
-	 * Clear all entries previously added
+	 * Clear all entries previously added and history of executions.
 	 *
 	 * @return {@link SwitcherBuilder}
 	 */
 	public SwitcherBuilder flush() {
+		this.historyExecution.clear();
 		this.entry.clear();
 		return this;
 	}

--- a/src/main/java/com/switcherapi/client/model/SwitcherRequest.java
+++ b/src/main/java/com/switcherapi/client/model/SwitcherRequest.java
@@ -23,8 +23,6 @@ public final class SwitcherRequest extends SwitcherBuilder {
 	private final SwitcherExecutor switcherExecutor;
 	
 	private final String switcherKey;
-	
-	private final Map<List<Entry>, SwitcherResult> historyExecution;
 
 	private AsyncSwitcher asyncSwitcher;
 	
@@ -41,7 +39,6 @@ public final class SwitcherRequest extends SwitcherBuilder {
 		super(switcherProperties);
 		this.switcherExecutor = switcherExecutor;
 		this.switcherKey = switcherKey;
-		this.historyExecution = new HashMap<>();
 	}
 	
 	@Override

--- a/src/test/java/com/switcherapi/client/SwitcherBasicCriteriaResponseTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherBasicCriteriaResponseTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SwitcherBasicCriteriaResponseTest extends MockWebServerHelper {
@@ -31,7 +32,7 @@ class SwitcherBasicCriteriaResponseTest extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));

--- a/src/test/java/com/switcherapi/client/SwitcherBasicTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherBasicTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -28,7 +29,7 @@ class SwitcherBasicTest extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));

--- a/src/test/java/com/switcherapi/client/SwitcherContextBuilderTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherContextBuilderTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Paths;
 
 import static com.switcherapi.SwitchersBase.*;
 import static com.switcherapi.client.SwitcherContextValidator.ERR_LOCAL;
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SwitcherContextBuilderTest {
@@ -26,7 +27,7 @@ class SwitcherContextBuilderTest {
 				.apiKey("API_KEY")
 				.domain("switcher-domain")
 				.component("switcher-client")
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.snapshotLocation(SNAPSHOTS_LOCAL)
 				.local(true));
 		
@@ -46,7 +47,7 @@ class SwitcherContextBuilderTest {
 				.apiKey("API_KEY")
 				.domain("switcher-domain")
 				.component("switcher-client")
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.snapshotLocation(null)
 				.local(true));
 

--- a/src/test/java/com/switcherapi/client/SwitcherContextRemoteExecutorTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherContextRemoteExecutorTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SwitcherContextRemoteExecutorTest extends MockWebServerHelper {
@@ -41,7 +42,7 @@ class SwitcherContextRemoteExecutorTest extends MockWebServerHelper {
 				.apiKey("API_KEY")
 				.domain("switcher-domain")
 				.component("switcher-client-pool-test")
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.poolConnectionSize(1)
 				.local(false));
 
@@ -72,7 +73,7 @@ class SwitcherContextRemoteExecutorTest extends MockWebServerHelper {
 				.apiKey("API_KEY")
 				.domain("switcher-domain")
 				.component("switcher-client-timeout-test")
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.timeoutMs(500)
 				.local(false));
 

--- a/src/test/java/com/switcherapi/client/SwitcherFail1Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherFail1Test.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SwitcherFail1Test extends MockWebServerHelper {
@@ -43,7 +44,7 @@ class SwitcherFail1Test extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));

--- a/src/test/java/com/switcherapi/client/SwitcherFail2Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherFail2Test.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -40,7 +41,7 @@ class SwitcherFail2Test extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));

--- a/src/test/java/com/switcherapi/client/SwitcherSilentModeTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSilentModeTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Paths;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SwitcherSilentModeTest extends MockWebServerHelper {
@@ -41,7 +42,7 @@ class SwitcherSilentModeTest extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));

--- a/src/test/java/com/switcherapi/client/SwitcherSnapshotLookupTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSnapshotLookupTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -52,7 +53,7 @@ class SwitcherSnapshotLookupTest extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));

--- a/src/test/java/com/switcherapi/client/SwitcherSnapshotValidationFailTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSnapshotValidationFailTest.java
@@ -12,6 +12,7 @@ import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -46,7 +47,7 @@ class SwitcherSnapshotValidationFailTest extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));

--- a/src/test/java/com/switcherapi/client/SwitcherSnapshotValidationTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSnapshotValidationTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Paths;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SwitcherSnapshotValidationTest extends MockWebServerHelper {
@@ -43,7 +44,7 @@ class SwitcherSnapshotValidationTest extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));
@@ -105,7 +106,7 @@ class SwitcherSnapshotValidationTest extends MockWebServerHelper {
 				.local(true)
 				.snapshotAutoLoad(false)
 				.snapshotLocation(RESOURCES_PATH)
-				.environment("default"));
+				.environment(DEFAULT_ENV));
 		
 		Switchers.initializeClient();
 		
@@ -129,7 +130,7 @@ class SwitcherSnapshotValidationTest extends MockWebServerHelper {
 				.local(false)
 				.snapshotAutoLoad(false)
 				.snapshotLocation(RESOURCES_PATH)
-				.environment("default"));
+				.environment(DEFAULT_ENV));
 		
 		Switchers.initializeClient();
 		

--- a/src/test/java/com/switcherapi/client/SwitcherValidateTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherValidateTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SwitcherValidateTest extends MockWebServerHelper {
@@ -42,7 +43,7 @@ class SwitcherValidateTest extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));

--- a/src/test/java/com/switcherapi/client/service/local/SwitcherLocalServiceTest.java
+++ b/src/test/java/com/switcherapi/client/service/local/SwitcherLocalServiceTest.java
@@ -1,5 +1,6 @@
 package com.switcherapi.client.service.local;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static com.switcherapi.client.remote.Constants.DEFAULT_TIMEOUT;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -39,7 +40,7 @@ class SwitcherLocalServiceTest {
 		SwitchersBase.configure(ContextBuilder.builder()
 				.context(SwitchersBase.class.getName())
 				.snapshotLocation(SNAPSHOTS_LOCAL)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.local(true));
 
 		SwitcherProperties properties = SwitchersBase.getSwitcherProperties();

--- a/src/test/java/com/switcherapi/client/utils/SnapshotWatcherWorkerTest.java
+++ b/src/test/java/com/switcherapi/client/utils/SnapshotWatcherWorkerTest.java
@@ -6,6 +6,8 @@ import com.switcherapi.fixture.CountDownHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
+
 class SnapshotWatcherWorkerTest extends SnapshotTest {
 
 	@BeforeAll
@@ -13,7 +15,7 @@ class SnapshotWatcherWorkerTest extends SnapshotTest {
 		SwitchersBase.configure(ContextBuilder.builder(true)
 			.context(SwitchersBase.class.getName())
 			.snapshotLocation(SNAPSHOTS_LOCAL)
-			.environment("default")
+			.environment(DEFAULT_ENV)
 			.local(true));
 
 		SwitchersBase.initializeClient();

--- a/src/test/java/com/switcherapi/client/utils/SwitcherUtilsTest.java
+++ b/src/test/java/com/switcherapi/client/utils/SwitcherUtilsTest.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.Properties;
 import java.util.stream.Stream;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SwitcherUtilsTest {
@@ -116,7 +117,7 @@ class SwitcherUtilsTest {
 	 */
 	static Stream<Arguments> envArguments() {
 	    return Stream.of(
-			Arguments.of("default", "default"),
+			Arguments.of(DEFAULT_ENV, DEFAULT_ENV),
 			Arguments.of("${PORT:8080}", "8080"),
 			Arguments.of("${SNAPSHOT_LOCAL:}", ""),
 			Arguments.of("${ENVIRONMENT}", "staging")


### PR DESCRIPTION
This pull request introduces improvements to the handling of execution history in the `SwitcherBuilder` class and refactors test code to use a constant for the default environment, improving maintainability and consistency. The most significant change is the centralization of the `historyExecution` map in `SwitcherBuilder`, along with updates to test setup and usage patterns.

### Core library improvements

* Moved the `historyExecution` map from `SwitcherRequest` to `SwitcherBuilder`, ensuring execution history is managed at the builder level and simplifying the class hierarchy. The `flush()` method now clears both entries and execution history. (`src/main/java/com/switcherapi/client/model/SwitcherBuilder.java`, `src/main/java/com/switcherapi/client/model/SwitcherRequest.java`) [[1]](diffhunk://#diff-ac0544cec82f9e6e850d4929bf6edf6ba3397237b1bba0012f503cba484971e7L7-R7) [[2]](diffhunk://#diff-ac0544cec82f9e6e850d4929bf6edf6ba3397237b1bba0012f503cba484971e7R19-R20) [[3]](diffhunk://#diff-ac0544cec82f9e6e850d4929bf6edf6ba3397237b1bba0012f503cba484971e7R35-R46) [[4]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L27-L28) [[5]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L44)

### Test infrastructure modernization

* Refactored `SwitcherThrottleTest` to use `SwitchersBase` instead of `Switchers`, updated initialization and reset logic, and removed unnecessary test method annotations for better clarity and reliability. (`src/test/java/com/switcherapi/client/SwitcherThrottleTest.java`) [[1]](diffhunk://#diff-03f4ced8737d6fcdafc624973b0d4afe2cca92045b0ec2e9a3a8d7507ea7f807L3-R32) [[2]](diffhunk://#diff-03f4ced8737d6fcdafc624973b0d4afe2cca92045b0ec2e9a3a8d7507ea7f807L35-L50) [[3]](diffhunk://#diff-03f4ced8737d6fcdafc624973b0d4afe2cca92045b0ec2e9a3a8d7507ea7f807L60-R59) [[4]](diffhunk://#diff-03f4ced8737d6fcdafc624973b0d4afe2cca92045b0ec2e9a3a8d7507ea7f807L74-L77) [[5]](diffhunk://#diff-03f4ced8737d6fcdafc624973b0d4afe2cca92045b0ec2e9a3a8d7507ea7f807L87-R84)