### PR TITLE
feat: changed flush to clean execution history too (#379)

### DIFF
--- a/src/main/java/com/switcherapi/client/model/SwitcherBuilder.java
+++ b/src/main/java/com/switcherapi/client/model/SwitcherBuilder.java
@@ -4,9 +4,7 @@ import com.switcherapi.client.SwitcherProperties;
 import com.switcherapi.client.exception.SwitcherContextException;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * Builder class that simplifies how input are programmatically wrapped inside the Switcher.
@@ -17,6 +15,8 @@ import java.util.Objects;
 public abstract class SwitcherBuilder implements Switcher {
 
 	protected final SwitcherProperties properties;
+
+	protected final Map<List<Entry>, SwitcherResult> historyExecution;
 	
 	protected long delay;
 
@@ -32,16 +32,18 @@ public abstract class SwitcherBuilder implements Switcher {
 
 	protected SwitcherBuilder(final SwitcherProperties properties) {
 		this.properties = properties;
+		this.historyExecution = new HashMap<>();
 		this.entry = new ArrayList<>();
 		this.delay = 0;
 	}
 
 	/**
-	 * Clear all entries previously added
+	 * Clear all entries previously added and history of executions.
 	 *
 	 * @return {@link SwitcherBuilder}
 	 */
 	public SwitcherBuilder flush() {
+		this.historyExecution.clear();
 		this.entry.clear();
 		return this;
 	}

--- a/src/main/java/com/switcherapi/client/model/SwitcherRequest.java
+++ b/src/main/java/com/switcherapi/client/model/SwitcherRequest.java
@@ -23,8 +23,6 @@ public final class SwitcherRequest extends SwitcherBuilder {
 	private final SwitcherExecutor switcherExecutor;
 	
 	private final String switcherKey;
-	
-	private final Map<List<Entry>, SwitcherResult> historyExecution;
 
 	private AsyncSwitcher asyncSwitcher;
 	
@@ -41,7 +39,6 @@ public final class SwitcherRequest extends SwitcherBuilder {
 		super(switcherProperties);
 		this.switcherExecutor = switcherExecutor;
 		this.switcherKey = switcherKey;
-		this.historyExecution = new HashMap<>();
 	}
 	
 	@Override

--- a/src/test/java/com/switcherapi/client/SwitcherBasicCriteriaResponseTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherBasicCriteriaResponseTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SwitcherBasicCriteriaResponseTest extends MockWebServerHelper {
@@ -31,7 +32,7 @@ class SwitcherBasicCriteriaResponseTest extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));

--- a/src/test/java/com/switcherapi/client/SwitcherBasicTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherBasicTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -28,7 +29,7 @@ class SwitcherBasicTest extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));

--- a/src/test/java/com/switcherapi/client/SwitcherContextBuilderTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherContextBuilderTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Paths;
 
 import static com.switcherapi.SwitchersBase.*;
 import static com.switcherapi.client.SwitcherContextValidator.ERR_LOCAL;
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SwitcherContextBuilderTest {
@@ -26,7 +27,7 @@ class SwitcherContextBuilderTest {
 				.apiKey("API_KEY")
 				.domain("switcher-domain")
 				.component("switcher-client")
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.snapshotLocation(SNAPSHOTS_LOCAL)
 				.local(true));
 		
@@ -46,7 +47,7 @@ class SwitcherContextBuilderTest {
 				.apiKey("API_KEY")
 				.domain("switcher-domain")
 				.component("switcher-client")
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.snapshotLocation(null)
 				.local(true));
 

--- a/src/test/java/com/switcherapi/client/SwitcherContextRemoteExecutorTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherContextRemoteExecutorTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SwitcherContextRemoteExecutorTest extends MockWebServerHelper {
@@ -40,7 +41,7 @@ class SwitcherContextRemoteExecutorTest extends MockWebServerHelper {
 				.apiKey("API_KEY")
 				.domain("switcher-domain")
 				.component("switcher-client-pool-test")
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.poolConnectionSize(1)
 				.local(false));
 
@@ -66,7 +67,7 @@ class SwitcherContextRemoteExecutorTest extends MockWebServerHelper {
 				.apiKey("API_KEY")
 				.domain("switcher-domain")
 				.component("switcher-client-timeout-test")
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.timeoutMs(500)
 				.local(false));
 

--- a/src/test/java/com/switcherapi/client/SwitcherFail1Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherFail1Test.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SwitcherFail1Test extends MockWebServerHelper {
@@ -43,7 +44,7 @@ class SwitcherFail1Test extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));

--- a/src/test/java/com/switcherapi/client/SwitcherFail2Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherFail2Test.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -40,7 +41,7 @@ class SwitcherFail2Test extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));

--- a/src/test/java/com/switcherapi/client/SwitcherSilentModeTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSilentModeTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Paths;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SwitcherSilentModeTest extends MockWebServerHelper {
@@ -41,7 +42,7 @@ class SwitcherSilentModeTest extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));

--- a/src/test/java/com/switcherapi/client/SwitcherSnapshotLookupTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSnapshotLookupTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -52,7 +53,7 @@ class SwitcherSnapshotLookupTest extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));

--- a/src/test/java/com/switcherapi/client/SwitcherSnapshotValidationFailTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSnapshotValidationFailTest.java
@@ -12,6 +12,7 @@ import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -46,7 +47,7 @@ class SwitcherSnapshotValidationFailTest extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));

--- a/src/test/java/com/switcherapi/client/SwitcherSnapshotValidationTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSnapshotValidationTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Paths;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SwitcherSnapshotValidationTest extends MockWebServerHelper {
@@ -43,7 +44,7 @@ class SwitcherSnapshotValidationTest extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));
@@ -105,7 +106,7 @@ class SwitcherSnapshotValidationTest extends MockWebServerHelper {
 				.local(true)
 				.snapshotAutoLoad(false)
 				.snapshotLocation(RESOURCES_PATH)
-				.environment("default"));
+				.environment(DEFAULT_ENV));
 		
 		Switchers.initializeClient();
 		
@@ -129,7 +130,7 @@ class SwitcherSnapshotValidationTest extends MockWebServerHelper {
 				.local(false)
 				.snapshotAutoLoad(false)
 				.snapshotLocation(RESOURCES_PATH)
-				.environment("default"));
+				.environment(DEFAULT_ENV));
 		
 		Switchers.initializeClient();
 		

--- a/src/test/java/com/switcherapi/client/SwitcherThrottle1Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherThrottle1Test.java
@@ -1,0 +1,64 @@
+package com.switcherapi.client;
+
+import com.switcherapi.SwitchersBase;
+import com.switcherapi.client.model.Switcher;
+import com.switcherapi.fixture.CountDownHelper;
+import com.switcherapi.fixture.MockWebServerHelper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SwitcherThrottle1Test extends MockWebServerHelper {
+	
+	@BeforeAll
+	static void setup() throws IOException {
+		MockWebServerHelper.setupMockServer();
+
+		SwitchersBase.configure(ContextBuilder.builder(true)
+				.context(SwitchersBase.class.getName())
+				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
+				.apiKey("TEST_API_KEY")
+				.domain("TEST_DOMAIN")
+				.component("TEST_COMPONENT")
+				.environment(DEFAULT_ENV));
+
+		SwitchersBase.initializeClient();
+    }
+	
+	@AfterAll
+	static void tearDown() {
+		MockWebServerHelper.tearDownMockServer();
+    }
+	
+	@Test
+	void shouldReturnTrue_withThrottle() {
+		// Initial remote call
+		givenResponse(generateMockAuth(10)); //auth
+		givenResponse(generateCriteriaResponse("true", false)); //criteria - sync (cached)
+		
+		// Throttle period - should use cache
+		givenResponse(generateCriteriaResponse("false", false)); //criteria - async (background)
+		givenResponse(generateCriteriaResponse("false", false)); //criteria - async after 1 sec (background)
+		
+		//test
+		Switcher switcher = SwitchersBase
+				.getSwitcher(SwitchersBase.USECASE11)
+				.flush()
+				.checkValue("value")
+				.throttle(1000);
+		
+		for (int i = 0; i < 100; i++) {
+			assertTrue(switcher.isItOn());
+		}
+
+		CountDownHelper.wait(1);
+		assertFalse(switcher.isItOn());
+	}
+
+}

--- a/src/test/java/com/switcherapi/client/SwitcherThrottle2Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherThrottle2Test.java
@@ -1,12 +1,11 @@
 package com.switcherapi.client;
 
 import com.switcherapi.SwitchersBase;
-import com.switcherapi.client.model.Switcher;
 import com.switcherapi.client.model.SwitcherBuilder;
-import com.switcherapi.fixture.CountDownHelper;
 import com.switcherapi.fixture.MockWebServerHelper;
-import mockwebserver3.QueueDispatcher;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -14,8 +13,7 @@ import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class SwitcherThrottleTest extends MockWebServerHelper {
+class SwitcherThrottle2Test extends MockWebServerHelper {
 	
 	@BeforeAll
 	static void setup() throws IOException {
@@ -28,47 +26,16 @@ class SwitcherThrottleTest extends MockWebServerHelper {
 				.domain("TEST_DOMAIN")
 				.component("TEST_COMPONENT")
 				.environment(DEFAULT_ENV));
+
+		SwitchersBase.initializeClient();
     }
 	
 	@AfterAll
 	static void tearDown() {
 		MockWebServerHelper.tearDownMockServer();
     }
-	
-	@BeforeEach
-	void resetSwitcherContextState() {
-		((QueueDispatcher) mockBackEnd.getDispatcher()).clear();
-		SwitchersBase.initializeClient();
-	}
-	
-	@Test
-	@Order(1)
-	void shouldReturnTrue_withThrottle() {
-		// Initial remote call
-		givenResponse(generateMockAuth(10)); //auth
-		givenResponse(generateCriteriaResponse("true", false)); //criteria - sync (cached)
-		
-		// Throttle period - should use cache
-		givenResponse(generateCriteriaResponse("false", false)); //criteria - async (background)
-		givenResponse(generateCriteriaResponse("false", false)); //criteria - async after 1 sec (background)
-		
-		//test
-		Switcher switcher = SwitchersBase
-				.getSwitcher(SwitchersBase.USECASE11)
-				.flush()
-				.checkValue("value")
-				.throttle(1000);
-		
-		for (int i = 0; i < 100; i++) {
-			assertTrue(switcher.isItOn());
-		}
-
-		CountDownHelper.wait(1);
-		assertFalse(switcher.isItOn());
-	}
 
 	@Test
-	@Order(2)
 	void shouldRetrieveNewResponse_whenStrategyInputChanged() {
 		// Initial remote call
 		givenResponse(generateMockAuth(10)); //auth

--- a/src/test/java/com/switcherapi/client/SwitcherThrottleTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherThrottleTest.java
@@ -6,10 +6,7 @@ import com.switcherapi.client.model.SwitcherBuilder;
 import com.switcherapi.fixture.CountDownHelper;
 import com.switcherapi.fixture.MockWebServerHelper;
 import mockwebserver3.QueueDispatcher;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 
@@ -17,6 +14,7 @@ import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class SwitcherThrottleTest extends MockWebServerHelper {
 	
 	@BeforeAll
@@ -44,6 +42,7 @@ class SwitcherThrottleTest extends MockWebServerHelper {
 	}
 	
 	@Test
+	@Order(1)
 	void shouldReturnTrue_withThrottle() {
 		// Initial remote call
 		givenResponse(generateMockAuth(10)); //auth
@@ -69,6 +68,7 @@ class SwitcherThrottleTest extends MockWebServerHelper {
 	}
 
 	@Test
+	@Order(2)
 	void shouldRetrieveNewResponse_whenStrategyInputChanged() {
 		// Initial remote call
 		givenResponse(generateMockAuth(10)); //auth

--- a/src/test/java/com/switcherapi/client/SwitcherValidateTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherValidateTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SwitcherValidateTest extends MockWebServerHelper {
@@ -42,7 +43,7 @@ class SwitcherValidateTest extends MockWebServerHelper {
 				.local(false)
 				.snapshotLocation(null)
 				.snapshotSkipValidation(false)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.silentMode(null)
 				.snapshotAutoLoad(false)
 				.snapshotAutoUpdateInterval(null));

--- a/src/test/java/com/switcherapi/client/service/local/SwitcherLocalServiceTest.java
+++ b/src/test/java/com/switcherapi/client/service/local/SwitcherLocalServiceTest.java
@@ -1,5 +1,6 @@
 package com.switcherapi.client.service.local;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
 import static com.switcherapi.client.remote.Constants.DEFAULT_TIMEOUT;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -39,7 +40,7 @@ class SwitcherLocalServiceTest {
 		SwitchersBase.configure(ContextBuilder.builder()
 				.context(SwitchersBase.class.getName())
 				.snapshotLocation(SNAPSHOTS_LOCAL)
-				.environment("default")
+				.environment(DEFAULT_ENV)
 				.local(true));
 
 		SwitcherProperties properties = SwitchersBase.getSwitcherProperties();

--- a/src/test/java/com/switcherapi/client/utils/SnapshotWatcherWorkerTest.java
+++ b/src/test/java/com/switcherapi/client/utils/SnapshotWatcherWorkerTest.java
@@ -6,6 +6,8 @@ import com.switcherapi.fixture.CountDownHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
+
 class SnapshotWatcherWorkerTest extends SnapshotTest {
 
 	@BeforeAll
@@ -13,7 +15,7 @@ class SnapshotWatcherWorkerTest extends SnapshotTest {
 		SwitchersBase.configure(ContextBuilder.builder(true)
 			.context(SwitchersBase.class.getName())
 			.snapshotLocation(SNAPSHOTS_LOCAL)
-			.environment("default")
+			.environment(DEFAULT_ENV)
 			.local(true));
 
 		SwitchersBase.initializeClient();

--- a/src/test/java/com/switcherapi/client/utils/SwitcherUtilsTest.java
+++ b/src/test/java/com/switcherapi/client/utils/SwitcherUtilsTest.java
@@ -29,6 +29,8 @@ import com.switcherapi.client.exception.SwitcherContextException;
 import com.switcherapi.client.exception.SwitcherSnapshotLoadException;
 import com.switcherapi.client.model.ContextKey;
 
+import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
+
 class SwitcherUtilsTest {
 	
 	private static final String SNAPSHOTS_LOCAL = Paths.get(StringUtils.EMPTY).toAbsolutePath() + "/src/test/resources";
@@ -121,7 +123,7 @@ class SwitcherUtilsTest {
 	 */
 	static Stream<Arguments> envArguments() {
 	    return Stream.of(
-			Arguments.of("default", "default"),
+			Arguments.of(DEFAULT_ENV, DEFAULT_ENV),
 			Arguments.of("${PORT:8080}", "8080"),
 			Arguments.of("${SNAPSHOT_LOCAL:}", ""),
 			Arguments.of("${ENVIRONMENT}", "staging")


### PR DESCRIPTION
This pull request introduces improvements to the handling of execution history in the SwitcherBuilder class and refactors test code to use a constant for the default environment, improving maintainability and consistency. The most significant change is the centralization of the historyExecution map in SwitcherBuilder, along with updates to test setup and usage patterns.

### Environment configuration improvements

* Replaced all instances of the hardcoded `"default"` environment string with the `DEFAULT_ENV` constant from `com.switcherapi.client.remote.Constants` across all test classes, improving maintainability and reducing duplication. [[1]](diffhunk://#diff-1637d741bf06576210932de03cfd3051e896beafa7cdeb07bb977f1f84c1c3beL34-R35) [[2]](diffhunk://#diff-3d8fc35838bbce9ed2e039cdb404eeeee57d575f3f7c0b2416a4a4e1baafc1feL31-R32) [[3]](diffhunk://#diff-bb42bc1f7b15ae7c040873c7b2db438ececce1deb5e117b6c7c9fe20c1e3a889L29-R30) [[4]](diffhunk://#diff-bb42bc1f7b15ae7c040873c7b2db438ececce1deb5e117b6c7c9fe20c1e3a889L49-R50) [[5]](diffhunk://#diff-f1d3661ce1b0c3a9b103244e3c9a662d90c0bb6a59ba3977df911194fcbd9b3bL43-R44) [[6]](diffhunk://#diff-f1d3661ce1b0c3a9b103244e3c9a662d90c0bb6a59ba3977df911194fcbd9b3bL69-R70) [[7]](diffhunk://#diff-79e736139b0d0ca191208c364ce0faecc8229574afd5da97276668dca3cc21d8L46-R47) [[8]](diffhunk://#diff-0af7c1086ccc956e392806c7215b0da99d8465858fa92332553bfcee34ecdc9eL43-R44) [[9]](diffhunk://#diff-68675ebc3cb8a0523258700aaa4aa2983b9043bd0fc955a51bb50ac8e5bd0e1aL44-R45) [[10]](diffhunk://#diff-00fc1bcf86d8ee83701c9708940f283ae527fd2439edc0a00c439939ce3b0d8dL55-R56) [[11]](diffhunk://#diff-402e7db671137e16b4cd14d42958e801ce3bb2d61b5c31c0ecb163007113c0d1L49-R50) [[12]](diffhunk://#diff-1d615c3f4dc4e603c985802ee5a56e4886534ee5cbe44ef90e53f59138e1e5b5L46-R47) [[13]](diffhunk://#diff-1d615c3f4dc4e603c985802ee5a56e4886534ee5cbe44ef90e53f59138e1e5b5L108-R109) [[14]](diffhunk://#diff-1d615c3f4dc4e603c985802ee5a56e4886534ee5cbe44ef90e53f59138e1e5b5L132-R133) [[15]](diffhunk://#diff-03f4ced8737d6fcdafc624973b0d4afe2cca92045b0ec2e9a3a8d7507ea7f807L3-R32) [[16]](diffhunk://#diff-ed1c2d69970b6f3b98874d89cb30c385596217ea9b2ff49b4b79472920928614R16)

### SwitcherBuilder and execution history refactor

* Moved the `historyExecution` map from `SwitcherRequest` to the base `SwitcherBuilder` class, centralizing execution history management for all builder subclasses. [[1]](diffhunk://#diff-ac0544cec82f9e6e850d4929bf6edf6ba3397237b1bba0012f503cba484971e7R19-R20) [[2]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L27-L28) [[3]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L44)
* Ensured that the `flush()` method in `SwitcherBuilder` now clears both entries and execution history, improving the reset logic for builder state.

### Test and usage updates

* Refactored `SwitcherThrottleTest` to use `SwitcherBase` and the new environment configuration, and removed unnecessary test ordering and initialization calls for clarity and consistency. [[1]](diffhunk://#diff-03f4ced8737d6fcdafc624973b0d4afe2cca92045b0ec2e9a3a8d7507ea7f807L3-R32) [[2]](diffhunk://#diff-03f4ced8737d6fcdafc624973b0d4afe2cca92045b0ec2e9a3a8d7507ea7f807L35-L50) [[3]](diffhunk://#diff-03f4ced8737d6fcdafc624973b0d4afe2cca92045b0ec2e9a3a8d7507ea7f807L60-R59) [[4]](diffhunk://#diff-03f4ced8737d6fcdafc624973b0d4afe2cca92045b0ec2e9a3a8d7507ea7f807L74-L77) [[5]](diffhunk://#diff-03f4ced8737d6fcdafc624973b0d4afe2cca92045b0ec2e9a3a8d7507ea7f807L87-R84)