### PR TITLE
feat: improved async performance with thread-safe type

### DIFF
--- a/src/main/java/com/switcherapi/client/model/AsyncSwitcher.java
+++ b/src/main/java/com/switcherapi/client/model/AsyncSwitcher.java
@@ -46,7 +46,7 @@ public class AsyncSwitcher {
 	 * Validate if next run is ready to be performed, otherwise it will skip and delegate the
 	 * Switcher result for the Switcher history execution.
 	 */
-	public synchronized void execute() {
+	public void execute() {
 		SwitcherUtils.debug(logger, "nextRun: {} - currentTimeMillis: {}", nextRun, System.currentTimeMillis());
 		
 		if (nextRun < System.currentTimeMillis()) {

--- a/src/main/java/com/switcherapi/client/model/SwitcherBuilder.java
+++ b/src/main/java/com/switcherapi/client/model/SwitcherBuilder.java
@@ -15,8 +15,6 @@ import java.util.*;
 public abstract class SwitcherBuilder implements Switcher {
 
 	protected final SwitcherProperties properties;
-
-	protected final Map<List<Entry>, SwitcherResult> historyExecution;
 	
 	protected long delay;
 
@@ -32,7 +30,6 @@ public abstract class SwitcherBuilder implements Switcher {
 
 	protected SwitcherBuilder(final SwitcherProperties properties) {
 		this.properties = properties;
-		this.historyExecution = new HashMap<>();
 		this.entry = new ArrayList<>();
 		this.delay = 0;
 	}
@@ -42,11 +39,7 @@ public abstract class SwitcherBuilder implements Switcher {
 	 *
 	 * @return {@link SwitcherBuilder}
 	 */
-	public SwitcherBuilder flush() {
-		this.historyExecution.clear();
-		this.entry.clear();
-		return this;
-	}
+	public abstract SwitcherBuilder flush();
 	
 	/**
 	 * Skip API calls given a delay time

--- a/src/main/java/com/switcherapi/client/service/local/ClientLocalService.java
+++ b/src/main/java/com/switcherapi/client/service/local/ClientLocalService.java
@@ -4,11 +4,11 @@ import com.switcherapi.client.exception.SwitcherException;
 import com.switcherapi.client.exception.SwitcherKeyNotFoundException;
 import com.switcherapi.client.model.Entry;
 import com.switcherapi.client.model.SwitcherRequest;
+import com.switcherapi.client.model.SwitcherResult;
 import com.switcherapi.client.model.criteria.Config;
 import com.switcherapi.client.model.criteria.Domain;
 import com.switcherapi.client.model.criteria.Group;
 import com.switcherapi.client.model.criteria.StrategyConfig;
-import com.switcherapi.client.model.SwitcherResult;
 import com.switcherapi.client.service.SwitcherFactory;
 import com.switcherapi.client.service.SwitcherValidator;
 import com.switcherapi.client.utils.SwitcherUtils;
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -72,7 +73,7 @@ public class ClientLocalService implements ClientLocal {
 		for (final Group group : domain.getGroup()) {
 			config = findConfigInGroup(group, switcher.getSwitcherKey());
 
-			if (config != null) {
+			if (Objects.nonNull(config)) {
 				return getSwitcherResult(switcher, group, config);
 			}
 		}
@@ -101,10 +102,13 @@ public class ClientLocalService implements ClientLocal {
 	}
 
 	private Config findConfigInGroup(final Group group, final String switcherKey) {
-		return Arrays.stream(group.getConfig())
-				.filter(c -> c.getKey().equals(switcherKey))
-				.findFirst()
-				.orElse(null);
+		for (Config config : group.getConfig()) {
+			if (config.getKey().equals(switcherKey)) {
+				return config;
+			}
+		}
+
+		return null;
 	}
 
 	/**
@@ -126,7 +130,7 @@ public class ClientLocalService implements ClientLocal {
 
 			final Entry switcherInput = tryGetSwitcherInput(input, strategyConfig);
 			
-			if (switcherInput == null) {
+			if (Objects.isNull(switcherInput)) {
 				return strategyFailed(switcher, strategyConfig, STRATEGY_FAIL_NO_INPUT_PATTERN);
 			}
 
@@ -143,7 +147,7 @@ public class ClientLocalService implements ClientLocal {
 	}
 	
 	private Entry tryGetSwitcherInput(final List<Entry> input, StrategyConfig strategyConfig) {
-		if (input == null) {
+		if (Objects.isNull(input)) {
 			return null;
 		}
 		


### PR DESCRIPTION
This pull request refactors how history execution is managed in the `SwitcherBuilder` and its concrete implementation `SwitcherRequest`, improves thread safety, and simplifies null checks across the codebase. The main theme is to make the history execution logic more robust and concurrent, while also standardizing null checks using `Objects.nonNull` and `Objects.isNull`.

### History Execution Refactor

* Moved the `historyExecution` map from the abstract `SwitcherBuilder` to the concrete `SwitcherRequest` class, and changed its implementation from a regular `HashMap` to a thread-safe `ConcurrentHashMap` for better concurrency support. (`[[1]](diffhunk://#diff-ac0544cec82f9e6e850d4929bf6edf6ba3397237b1bba0012f503cba484971e7L19-L20)`, `[[2]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710R27-R28)`, `[[3]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710R48)`)
* Changed the `flush` method in `SwitcherBuilder` to be abstract, with `SwitcherRequest` now implementing it to clear both `entry` and `historyExecution`. (`[[1]](diffhunk://#diff-ac0544cec82f9e6e850d4929bf6edf6ba3397237b1bba0012f503cba484971e7L45-R42)`, `[[2]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710R72-R78)`)

### Thread Safety and Synchronization

* Removed the `synchronized` keyword from the `execute` method in `AsyncSwitcher`, potentially improving performance and relying on the thread safety of the underlying data structures. (`[src/main/java/com/switcherapi/client/model/AsyncSwitcher.javaL49-R49](diffhunk://#diff-c4e53fc6b375fc5ce77e080aa254d0321fef50ebdb25a7ccf460bbf9a2c4041dL49-R49)`)

## [Before] Operations /s in 5s
| Benchmark                                         | Type   | Mode  | Score           | Units |
|:--------------------------------------------------|:-------|:------|:----------------|:------|
| ClientJavaBenchmark.testSwitcherRemoteThrottle    | Async  | thrpt | 40,171,215.842  | ops/s |
| ClientJavaBenchmark.testSwitcherLocal             | Local  | thrpt | 19,689,072.262  | ops/s |

## [After] Operations /s in 5s
| Benchmark                                         | Type   | Mode  | Score           | Units |
|:--------------------------------------------------|:-------|:------|:----------------|:------|
| ClientJavaBenchmark.testSwitcherRemoteThrottle    | Async  | thrpt | 109,325,445.942 | ops/s |
| ClientJavaBenchmark.testSwitcherLocal             | Local  | thrpt | 41,501,007.578  | ops/s |