### PR TITLE
feat: added keepExecutions state to improve resource allocation (#383)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ switcher.isItOn();
 Create chained calls to validate the switcher with a more readable and maintainable code.
 
 ```java
-import static **.MyAppFeatures.*;
+import static org.example.MyAppFeatures.*;
 
 getSwitcher(FEATURE01)
 	.checkValue("My value")
@@ -198,10 +198,22 @@ getSwitcher(FEATURE01)
 ```
 
 4. **Accessing the last SwitcherResult**
-Switchers stores the last execution result, which can be retrieved using the following operation.
+Switchers stores the last execution result, which can be retrieved using the following operation. Requires enabling executions history for each Switcher using:
 
 ```java
-switcher.getLastExecutionResult();
+getSwitcher(FEATURE01)
+    .keepExecutions();
+	.checkValue("My value")
+	.checkNetwork("10.0.0.1")
+
+switcher.isItOn();
+switcher.getLastExecutionResult(); // returns the last SwitcherResult
+```
+
+Executions history can also be cleared using:
+
+```java
+switcher.flushExecutions();
 ```
 
 5. **Throttling**

--- a/src/main/java/com/switcherapi/client/SwitcherContextBase.java
+++ b/src/main/java/com/switcherapi/client/SwitcherContextBase.java
@@ -399,7 +399,7 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 		
 		final SwitcherRequest switcher = switchers.get(key);
 		if (!keepEntries) {
-			switcher.flush();
+			switcher.resetInputs();
 		}
 		
 		return switcher;

--- a/src/main/java/com/switcherapi/client/model/AsyncSwitcher.java
+++ b/src/main/java/com/switcherapi/client/model/AsyncSwitcher.java
@@ -44,7 +44,7 @@ public class AsyncSwitcher {
 
 	/**
 	 * Validate if next run is ready to be performed, otherwise it will skip and delegate the
-	 * Switcher result for the Switcher history execution.
+	 * Switcher result for the Switcher executions map.
 	 */
 	public void execute() {
 		SwitcherUtils.debug(logger, "nextRun: {} - currentTimeMillis: {}", nextRun, System.currentTimeMillis());
@@ -60,7 +60,7 @@ public class AsyncSwitcher {
 	public void run() {
 		try {
 			final SwitcherResult response = switcher.executeCriteria();
-			switcher.updateHistoryExecution(response);
+			switcher.updateExecutions(response);
 		} catch (SwitcherException e) {
 			logger.error(e.getMessage(), e);
 		}

--- a/src/main/java/com/switcherapi/client/model/Switcher.java
+++ b/src/main/java/com/switcherapi/client/model/Switcher.java
@@ -26,6 +26,13 @@ import java.util.List;
 public interface Switcher {
 
 	/**
+	 * Clear executions from SwitcherRequest
+	 *
+	 * @return instance of SwitcherInterface
+	 */
+	Switcher flushExecutions();
+
+	/**
 	 * Prepare the Switcher including a list of inputs necessary to run the criteria afterward.
 	 *
 	 * @param entry input object
@@ -77,11 +84,11 @@ public interface Switcher {
 	SwitcherResult executeCriteria();
 
 	/**
-	 * Update the history of executions.
+	 * Update Switcher executions.
 	 *
 	 * @param response the response to be updated
 	 */
-	void updateHistoryExecution(SwitcherResult response);
+	void updateExecutions(SwitcherResult response);
 
 	/**
 	 * Get the key of the switcher.

--- a/src/main/java/com/switcherapi/client/model/SwitcherBuilder.java
+++ b/src/main/java/com/switcherapi/client/model/SwitcherBuilder.java
@@ -22,6 +22,8 @@ public abstract class SwitcherBuilder implements Switcher {
 
 	protected boolean bypassMetrics;
 
+	protected boolean keepExecutions;
+
 	protected Boolean restrictRelay;
 
 	protected String defaultResult;
@@ -35,11 +37,14 @@ public abstract class SwitcherBuilder implements Switcher {
 	}
 
 	/**
-	 * Clear all entries previously added and history of executions.
+	 * Clear all entries previously added
 	 *
 	 * @return {@link SwitcherBuilder}
 	 */
-	public abstract SwitcherBuilder flush();
+	public SwitcherBuilder resetInputs() {
+		this.entry.clear();
+		return this;
+	}
 	
 	/**
 	 * Skip API calls given a delay time
@@ -48,6 +53,7 @@ public abstract class SwitcherBuilder implements Switcher {
 	 * @return {@link SwitcherBuilder}
 	 */
 	public SwitcherBuilder throttle(long delay) {
+		this.keepExecutions();
 		this.delay = delay;
 		return this;
 	}
@@ -184,6 +190,16 @@ public abstract class SwitcherBuilder implements Switcher {
 	 */
 	public SwitcherBuilder bypassMetrics() {
 		this.bypassMetrics = true;
+		return this;
+	}
+
+	/**
+	 * Keep executions in memory
+	 *
+	 * @return {@link SwitcherBuilder}
+	 */
+	public SwitcherBuilder keepExecutions() {
+		this.keepExecutions = true;
 		return this;
 	}
 

--- a/src/test/java/com/switcherapi/client/SwitcherBasicCriteriaResponseTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherBasicCriteriaResponseTest.java
@@ -96,7 +96,7 @@ class SwitcherBasicCriteriaResponseTest extends MockWebServerHelper {
 
 		//test
 		switcherBuilder
-				.flush()
+				.resetInputs()
 				.checkValue("anotherValue");
 
 		assertEquals(1, switcherBuilder.getEntry().size());

--- a/src/test/java/com/switcherapi/client/SwitcherLocal1Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherLocal1Test.java
@@ -7,6 +7,8 @@ import com.switcherapi.client.exception.SwitcherKeyNotFoundException;
 import com.switcherapi.client.model.ContextKey;
 import com.switcherapi.client.model.Entry;
 import com.switcherapi.client.model.StrategyValidator;
+import com.switcherapi.client.model.Switcher;
+import com.switcherapi.client.model.SwitcherBuilder;
 import com.switcherapi.client.model.SwitcherRequest;
 import com.switcherapi.fixture.Product;
 import com.google.gson.Gson;
@@ -49,35 +51,53 @@ class SwitcherLocal1Test {
 	
 	@Test
 	void localShouldReturnTrue() {
-		SwitcherRequest switcher = Switchers.getSwitcher(Switchers.USECASE11, true);
+		Switcher switcher = Switchers.getSwitcher(Switchers.USECASE11, true)
+				.keepExecutions();
 
 		assertNull(switcher.getLastExecutionResult());
 		assertTrue(switcher.isItOn());
 
-		// check result history
+		// check result from executions
 		assertTrue(switcher.getLastExecutionResult().isItOn());
 	}
 
 	@Test
 	void localShouldReturnTrueUsingFriendlyConstantName() {
-		SwitcherRequest switcher = Switchers.getSwitcher(Switchers.friendlyFeatureName, true);
+		Switcher switcher = Switchers.getSwitcher(Switchers.friendlyFeatureName, true)
+				.keepExecutions();
 
 		assertNull(switcher.getLastExecutionResult());
 		assertTrue(switcher.isItOn());
 
-		// check result history
+		// check result from executions
 		assertTrue(switcher.getLastExecutionResult().isItOn());
 	}
 	
 	@Test
 	void localShouldReturnFalse() {
-		SwitcherRequest switcher = Switchers.getSwitcher(Switchers.USECASE12);
+		Switcher switcher = Switchers.getSwitcher(Switchers.USECASE12)
+				.keepExecutions();
 
 		assertNull(switcher.getLastExecutionResult());
 		assertFalse(switcher.isItOn());
 
-		// check result history
+		// check result from executions
 		assertFalse(switcher.getLastExecutionResult().isItOn());
+	}
+
+	@Test
+	void localShouldCleanExecutions() {
+		SwitcherBuilder switcher = Switchers.getSwitcher(Switchers.USECASE11, true)
+				.keepExecutions();
+
+		assertNull(switcher.getLastExecutionResult());
+		assertTrue(switcher.isItOn());
+
+		// check result from executions
+		assertTrue(switcher.getLastExecutionResult().isItOn());
+		switcher.flushExecutions();
+
+		assertNull(switcher.getLastExecutionResult());
 	}
 	
 	@Test

--- a/src/test/java/com/switcherapi/client/SwitcherThrottle1Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherThrottle1Test.java
@@ -49,7 +49,8 @@ class SwitcherThrottle1Test extends MockWebServerHelper {
 		//test
 		Switcher switcher = SwitchersBase
 				.getSwitcher(SwitchersBase.USECASE11)
-				.flush()
+				.flushExecutions()
+				.resetInputs()
 				.checkValue("value")
 				.throttle(1000);
 		

--- a/src/test/java/com/switcherapi/client/SwitcherThrottle2Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherThrottle2Test.java
@@ -48,7 +48,8 @@ class SwitcherThrottle2Test extends MockWebServerHelper {
 		//test
 		SwitcherBuilder switcher = SwitchersBase
 				.getSwitcher(SwitchersBase.USECASE11)
-				.flush()
+				.flushExecutions()
+				.resetInputs()
 				.throttle(1000);
 
 		for (int i = 0; i < 100; i++) {


### PR DESCRIPTION
This pull request introduces a refactor to the Switcher executions history mechanism, replacing the previous "historyExecution" approach with a more explicit and maintainable "executionsMap". The changes clarify the API for managing executions, add new methods for controlling execution memory, and update documentation and tests to reflect the new behavior. This change should also considerably improve performance for local and remote if there is no need to keep the executions results.

### Executions History Refactor

* Replaced the `historyExecution` map with `executionsMap` in `SwitcherRequest`, and updated all related logic and method names to use the new terminology. This improves clarity and maintainability in how executions are stored and retrieved. [[1]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L27-R27) [[2]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L48-R54) [[3]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L97-R103) [[4]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L118-R120) [[5]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L134-R143)
* Added `flushExecutions()` to the `Switcher` interface and implemented it in `SwitcherRequest`, allowing users to explicitly clear stored executions. [[1]](diffhunk://#diff-3e0457e70125ca7a2162b2273e0bb7164d6b4b524b589264b7c1224e3b4f4b1dR28-R34) [[2]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L48-R54)
* Introduced `keepExecutions` flag and `keepExecutions()` method in `SwitcherBuilder` to enable/disable executions memory per switcher instance. [[1]](diffhunk://#diff-ac0544cec82f9e6e850d4929bf6edf6ba3397237b1bba0012f503cba484971e7R25-R26) [[2]](diffhunk://#diff-ac0544cec82f9e6e850d4929bf6edf6ba3397237b1bba0012f503cba484971e7R196-R205)

### API and Method Updates

* Deprecated and replaced `flush()` with `resetInputs()` for clearing input entries without affecting executions, and updated usages throughout the codebase and tests. [[1]](diffhunk://#diff-ac0544cec82f9e6e850d4929bf6edf6ba3397237b1bba0012f503cba484971e7L38-R47) [[2]](diffhunk://#diff-58fea277cde9b83cbb7929cce8f315b3577b69c0b7f98a82273c85e8a77d616eL402-R402) [[3]](diffhunk://#diff-1637d741bf06576210932de03cfd3051e896beafa7cdeb07bb977f1f84c1c3beL99-R99)
* Updated method names and documentation to use "executions" instead of "history", improving consistency and readability. [[1]](diffhunk://#diff-3e0457e70125ca7a2162b2273e0bb7164d6b4b524b589264b7c1224e3b4f4b1dL80-R91) [[2]](diffhunk://#diff-c4e53fc6b375fc5ce77e080aa254d0321fef50ebdb25a7ccf460bbf9a2c4041dL47-R47) [[3]](diffhunk://#diff-c4e53fc6b375fc5ce77e080aa254d0321fef50ebdb25a7ccf460bbf9a2c4041dL63-R63)

These changes collectively make executions management in the Switcher API more explicit, flexible, and easier to use and maintain.