### PR TITLE
feat: improved AsyncSwitcher performance, bump deps (#386)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 		<jersey-hk2.version>2.48</jersey-hk2.version>
 		<jersey-media-json-jackson.version>2.48</jersey-media-json-jackson.version>
 		<javax.activation-api.version>1.2.0</javax.activation-api.version>
-		<gson.version>2.13.2</gson.version>
+		<gson.version>2.14.0</gson.version>
 
 		<!-- utils -->
 		<commons-lang3.version>3.20.0</commons-lang3.version>
@@ -65,9 +65,9 @@
 
 		<!-- test -->
 		<okhttp.version>5.3.2</okhttp.version>
-		<junit-jupiter.version>5.14.3</junit-jupiter.version>
+		<junit-jupiter.version>5.14.4</junit-jupiter.version>
 		<junit-pioneer.version>1.9.1</junit-pioneer.version>
-		<junit-platform-launcher.version>1.14.3</junit-platform-launcher.version>
+		<junit-platform-launcher.version>1.14.4</junit-platform-launcher.version>
 
 		<!-- Plugins -->
 		<maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -75,7 +75,7 @@
 		<maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
 		<maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
 		<maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
-		<sonar-maven-plugin.version>5.5.0.6356</sonar-maven-plugin.version>
+		<sonar-maven-plugin.version>5.6.0.6792</sonar-maven-plugin.version>
 		<jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
 		<central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
 

--- a/src/main/java/com/switcherapi/client/model/AsyncSwitcher.java
+++ b/src/main/java/com/switcherapi/client/model/AsyncSwitcher.java
@@ -47,7 +47,9 @@ public class AsyncSwitcher {
 	 * Switcher result for the Switcher executions map.
 	 */
 	public void execute() {
-		SwitcherUtils.debug(logger, "nextRun: {} - currentTimeMillis: {}", nextRun, System.currentTimeMillis());
+		if (logger.isDebugEnabled()) {
+			SwitcherUtils.debug(logger, "nextRun: {} - currentTimeMillis: {}", nextRun, System.currentTimeMillis());
+		}
 		
 		if (nextRun < System.currentTimeMillis()) {
 			SwitcherUtils.debug(logger, "Running AsyncSwitcher");

--- a/src/test/java/com/switcherapi/client/SwitcherSnapshotAutoUpdate2Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSnapshotAutoUpdate2Test.java
@@ -1,0 +1,72 @@
+package com.switcherapi.client;
+
+import com.switcherapi.Switchers;
+import com.switcherapi.fixture.CountDownHelper;
+import com.switcherapi.fixture.MockWebServerHelper;
+import mockwebserver3.QueueDispatcher;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SwitcherSnapshotAutoUpdate2Test extends MockWebServerHelper {
+	
+	private static final String SNAPSHOTS_LOCAL = Paths.get(StringUtils.EMPTY).toAbsolutePath() + "/src/test/resources/update";
+
+	@BeforeAll
+	static void setup() throws IOException {
+        setupMockServer();
+        Switchers.loadProperties();
+    }
+
+	@AfterAll
+	static void tearDown() {
+		tearDownMockServer();
+		SwitcherContextBase.terminateSnapshotAutoUpdateWorker();
+    }
+
+	@BeforeEach
+	void restoreStubs() {
+		((QueueDispatcher) mockBackEnd.getDispatcher()).clear();
+		SwitcherContextBase.terminateSnapshotAutoUpdateWorker();
+
+		CountDownHelper.wait(1);
+	}
+
+	@Test
+	void shouldNotKillThread_whenAPI_wentLocal() {
+		//given
+		givenResponse(generateMockAuth(10)); //auth
+		givenResponse(generateSnapshotResponse("default_outdated.json", SNAPSHOTS_LOCAL)); //graphql
+
+		//that
+		Switchers.configure(ContextBuilder.builder(true)
+				.context(Switchers.class.getName())
+				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
+				.apiKey("[API_KEY]")
+				.environment("generated_mock_default_6")
+				.local(true)
+				.snapshotAutoLoad(true)
+				.snapshotAutoUpdateInterval("1s"));
+
+		Switchers.initializeClient();
+		assertEquals(1, Switchers.getSnapshotVersion());
+
+		CountDownHelper.wait(1);
+
+		//given - API is remote again
+		givenResponse(generateCheckSnapshotVersionResponse(Boolean.toString(false))); //criteria/snapshot_check
+		givenResponse(generateSnapshotResponse("default.json", SNAPSHOTS_LOCAL)); //graphql
+
+		//test
+		CountDownHelper.wait(2);
+		assertEquals(2, Switchers.getSnapshotVersion());
+	}
+
+}

--- a/src/test/java/com/switcherapi/client/SwitcherSnapshotAutoUpdateTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSnapshotAutoUpdateTest.java
@@ -185,37 +185,6 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 
 	@Test
 	@Order(5)
-	void shouldNotKillThread_whenAPI_wentLocal() {
-		//given
-		givenResponse(generateMockAuth(10)); //auth
-		givenResponse(generateSnapshotResponse("default_outdated.json", SNAPSHOTS_LOCAL)); //graphql
-
-		//that
-		Switchers.configure(ContextBuilder.builder(true)
-				.context(Switchers.class.getName())
-				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
-				.apiKey("[API_KEY]")
-				.environment("generated_mock_default_6")
-				.local(true)
-				.snapshotAutoLoad(true)
-				.snapshotAutoUpdateInterval("1s"));
-
-		Switchers.initializeClient();
-		assertEquals(1, Switchers.getSnapshotVersion());
-
-		CountDownHelper.wait(1);
-
-		//given - API is remote again
-		givenResponse(generateCheckSnapshotVersionResponse(Boolean.toString(false))); //criteria/snapshot_check
-		givenResponse(generateSnapshotResponse("default.json", SNAPSHOTS_LOCAL)); //graphql
-
-		//test
-		CountDownHelper.wait(2);
-		assertEquals(2, Switchers.getSnapshotVersion());
-	}
-
-	@Test
-	@Order(6)
 	void shouldRestartSnapshotAutoUpdate_whenAlreadySetup() {
 		//given - initialize (snapshot autoload)
 		givenResponse(generateMockAuth(10)); //auth

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,0 +1,17 @@
+# SLF4J SimpleLogger configuration
+# https://www.slf4j.org/api/org/slf4j/simple/SimpleLogger.html
+
+# Default log level for all loggers
+org.slf4j.simpleLogger.defaultLogLevel=info
+
+# DEBUG for the playground and the client library
+org.slf4j.simpleLogger.log.com.switcherapi.playground=debug
+org.slf4j.simpleLogger.log.com.switcherapi.client=debug
+
+# Date/time format
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS
+
+# Show the logger name (abbreviated)
+org.slf4j.simpleLogger.showShortLogName=true
+


### PR DESCRIPTION
Significant performance increase after wrapping debug log at the AsyncSwitcher.

# v2.5.2
| Benchmark                                         | Type   | Mode  | Score           | Units |
|:--------------------------------------------------|:-------|:------|:----------------|:------|
| ClientJavaBenchmark.testSwitcherRemoteThrottle    | Async  | thrpt | 112,963,043.838 | ops/s |

# v2.5.3
| Benchmark                                        | Type   | Mode  | Score           | Units |
|:-------------------------------------------------|:-------|:------|:----------------|:------|
| ClientJavaBenchmark.testSwitcherRemoteThrottle   | Async  | thrpt | 188,184,291.488 | ops/s |
