### PR TITLE
feat: added auto refresh token #388 (#389)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,28 +135,29 @@ switcher.poolsize=2
 
 ### Configuration Properties Reference
 
-| Property                            | Required | Default | Description                                                                          |
-|-------------------------------------|----------|---------|--------------------------------------------------------------------------------------|
-| `switcher.context`                  | ✅ | -       | Fully qualified class name extending SwitcherContext                                 |
-| `switcher.url`                      | ✅ | -       | Switcher API endpoint URL                                                            |
-| `switcher.apikey`                   | ✅ | -       | API key for authentication                                                           |
-| `switcher.component`                | ✅ | -       | Your application/component identifier                                                |
-| `switcher.domain`                   | ✅ | -       | Domain name in Switcher API                                                          |
-| `switcher.environment`              | ❌ | default | Environment name (dev, staging, default)                                             |
-| `switcher.local`                    | ❌ | false   | Enable local-only mode                                                               |
-| `switcher.check`                    | ❌ | false   | Validate switcher keys on startup                                                    |
-| `switcher.relay.restrict`           | ❌ | true    | Defines if client will trigger local snapshot relay verification                     |
-| `switcher.snapshot.location`        | ❌ | -       | Directory for snapshot files                                                         |
-| `switcher.snapshot.auto`            | ❌ | false   | Auto-load snapshots on startup                                                       |
-| `switcher.snapshot.skipvalidation`  | ❌ | false   | Skip snapshot validation on load                                                     |
-| `switcher.snapshot.updateinterval`  | ❌ | -       | Interval for automatic snapshot updates (e.g., "5s", "2m")                           |
-| `switcher.snapshot.watcher`         | ❌ | false   | Monitor snapshot files for changes                                                   |
-| `switcher.silent`                   | ❌ | -       | Enable silent mode (e.g., "5s", "2m")                                                |
-| `switcher.timeout`                  | ❌ | 3000    | API timeout in milliseconds                                                          |
-| `switcher.poolsize`                 | ❌ | 2       | Thread pool size for API calls                                                       |
-| `switcher.regextimeout` (v1-only)   | ❌ | 3000    | Time in ms given to Timed Match Worker used for local Regex (ReDoS safety mechanism) |
-| `switcher.truststore.path`          | ❌ | -       | Path to custom truststore file                                                       |
-| `switcher.truststore.password`      | ❌ | -       | Password for custom truststore                                                       |
+| Property                           | Required | Default | Description                                                                          |
+|------------------------------------|----------|---------|--------------------------------------------------------------------------------------|
+| `switcher.context`                 | ✅        | -       | Fully qualified class name extending SwitcherContext                                 |
+| `switcher.url`                     | ✅        | -       | Switcher API endpoint URL                                                            |
+| `switcher.apikey`                  | ✅        | -       | API key for authentication                                                           |
+| `switcher.component`               | ✅        | -       | Your application/component identifier                                                |
+| `switcher.domain`                  | ✅        | -       | Domain name in Switcher API                                                          |
+| `switcher.environment`             | ❌        | default | Environment name (dev, staging, default)                                             |
+| `switcher.local`                   | ❌        | false   | Enable local-only mode                                                               |
+| `switcher.check`                   | ❌        | false   | Validate switcher keys on startup                                                    |
+| `switcher.autorefreshtoken`        | ❌        | false   | Automatically refresh API token before expiration                                    |
+| `switcher.relay.restrict`          | ❌        | true    | Defines if client will trigger local snapshot relay verification                     |
+| `switcher.snapshot.location`       | ❌        | -       | Directory for snapshot files                                                         |
+| `switcher.snapshot.auto`           | ❌        | false   | Auto-load snapshots on startup                                                       |
+| `switcher.snapshot.skipvalidation` | ❌        | false   | Skip snapshot validation on load                                                     |
+| `switcher.snapshot.updateinterval` | ❌        | -       | Interval for automatic snapshot updates (e.g., "5s", "2m")                           |
+| `switcher.snapshot.watcher`        | ❌        | false   | Monitor snapshot files for changes                                                   |
+| `switcher.silent`                  | ❌        | -       | Enable silent mode (e.g., "5s", "2m")                                                |
+| `switcher.timeout`                 | ❌        | 3000    | API timeout in milliseconds                                                          |
+| `switcher.poolsize`                | ❌        | 2       | Thread pool size for API calls                                                       |
+| `switcher.regextimeout` (v1-only)  | ❌        | 3000    | Time in ms given to Timed Match Worker used for local Regex (ReDoS safety mechanism) |
+| `switcher.truststore.path`         | ❌        | -       | Path to custom truststore file                                                       |
+| `switcher.truststore.password`     | ❌        | -       | Password for custom truststore                                                       |
 
 > 💡 **Environment Variables**: Use `${ENV_VAR:default_value}` syntax for environment variable substitution.
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>com.switcherapi</groupId>
 	<artifactId>switcher-client</artifactId>
 	<packaging>jar</packaging>
-	<version>1.9.3-SNAPSHOT</version>
+	<version>1.10.0-SNAPSHOT</version>
 
 	<name>Switcher Client</name>
 	<description>Switcher Client SDK for working with Switcher API</description>

--- a/src/main/java/com/switcherapi/client/ContextBuilder.java
+++ b/src/main/java/com/switcherapi/client/ContextBuilder.java
@@ -246,4 +246,9 @@ public class ContextBuilder {
 				Optional.ofNullable(poolSize).orElse(DEFAULT_POOL_SIZE));
 		return this;
 	}
+
+	public ContextBuilder autoRefreshToken(boolean autoRefreshToken) {
+		switcherProperties.setValue(ContextKey.AUTO_REFRESH_TOKEN, autoRefreshToken);
+		return this;
+	}
 }

--- a/src/main/java/com/switcherapi/client/SwitcherConfig.java
+++ b/src/main/java/com/switcherapi/client/SwitcherConfig.java
@@ -12,6 +12,7 @@ abstract class SwitcherConfig {
 
 	protected boolean local;
 	protected boolean check;
+	protected boolean autoRefreshToken;
 	protected String silent;
 	protected Integer timeout;
 	protected Integer regexTimeout;
@@ -39,6 +40,7 @@ abstract class SwitcherConfig {
 		setEnvironment(properties.getValue(ContextKey.ENVIRONMENT));
 		setLocal(properties.getBoolean(ContextKey.LOCAL_MODE));
 		setCheck(properties.getBoolean(ContextKey.CHECK_SWITCHERS));
+		setAutoRefreshToken(properties.getBoolean(ContextKey.AUTO_REFRESH_TOKEN));
 		setSilent(properties.getValue(ContextKey.SILENT_MODE));
 		setTimeout(properties.getInt(ContextKey.TIMEOUT_MS));
 		setPoolSize(properties.getInt(ContextKey.POOL_CONNECTION_SIZE));
@@ -104,6 +106,10 @@ abstract class SwitcherConfig {
 
 	public void setCheck(boolean check) {
 		this.check = check;
+	}
+
+	public void setAutoRefreshToken(boolean autoRefreshToken) {
+		this.autoRefreshToken = autoRefreshToken;
 	}
 
 	public void setSilent(String silent) {

--- a/src/main/java/com/switcherapi/client/SwitcherContextBase.java
+++ b/src/main/java/com/switcherapi/client/SwitcherContextBase.java
@@ -87,7 +87,8 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 	protected static Set<String> switcherKeys;
 	protected static Map<String, SwitcherRequest> switchers;
 	protected static SwitcherExecutor switcherExecutor;
-	private static ScheduledExecutorService scheduledExecutorService;
+	private static ScheduledExecutorService scheduledSnapshotExecutorService;
+	private static ScheduledExecutorService scheduledTokenExecutorService;
 	private static ExecutorService watcherExecutorService;
 	private static SnapshotWatcher watcherSnapshot;
 	protected static SwitcherContextBase contextBase;
@@ -112,6 +113,7 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 				.silentMode(silent)
 				.regexTimeout(regexTimeout)
 				.timeoutMs(timeout)
+				.autoRefreshToken(autoRefreshToken)
 				.poolConnectionSize(poolSize)
 				.snapshotLocation(snapshot.getLocation())
 				.snapshotAutoLoad(snapshot.isAuto())
@@ -198,9 +200,12 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 	 * @return SwitcherExecutor instance
 	 */
 	private static SwitcherExecutor buildInstance() {
+		initTokenExecutorService();
+
 		final ClientWS clientWS = initRemotePoolExecutorService();
 		final SwitcherValidator validatorService = new ValidatorService();
-		final ClientRemote clientRemote = new ClientRemoteService(clientWS, switcherProperties);
+		final ClientRemote clientRemote = new ClientRemoteService(
+				clientWS, switcherProperties, scheduledTokenExecutorService);
 		final ClientLocal clientLocal = new ClientLocalService(validatorService);
 
 		if (contextBol(ContextKey.LOCAL_MODE)) {
@@ -307,7 +312,7 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 			return null;
 		}
 
-		if (Objects.nonNull(scheduledExecutorService)) {
+		if (Objects.nonNull(scheduledSnapshotExecutorService)) {
 			terminateSnapshotAutoUpdateWorker();
 		}
 
@@ -325,7 +330,7 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 		};
 
 		initSnapshotExecutorService();
-		return scheduledExecutorService.scheduleAtFixedRate(runnableSnapshotValidate, 0, interval, TimeUnit.MILLISECONDS);
+		return scheduledSnapshotExecutorService.scheduleAtFixedRate(runnableSnapshotValidate, 0, interval, TimeUnit.MILLISECONDS);
 	}
 
 	/**
@@ -340,12 +345,24 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 	}
 
 	/**
-	 * Configure Executor Service for Snapshot Update Worker
+	 * Configure Scheduled Executor Service for Snapshot Update Worker
 	 */
 	private static void initSnapshotExecutorService() {
-		scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(r -> {
+		scheduledSnapshotExecutorService = Executors.newSingleThreadScheduledExecutor(r -> {
 			Thread thread = new Thread(r);
 			thread.setName(WorkerName.SNAPSHOT_UPDATE_WORKER.toString());
+			thread.setDaemon(true);
+			return thread;
+		});
+	}
+
+	/**
+	 * Configure Scheduled Executor Service for Token Refresh Worker
+	 */
+	private static void initTokenExecutorService() {
+		scheduledTokenExecutorService = Executors.newSingleThreadScheduledExecutor(r -> {
+			Thread thread = new Thread(r);
+			thread.setName(WorkerName.SWITCHER_TOKEN_WORKER.toString());
 			thread.setDaemon(true);
 			return thread;
 		});
@@ -539,9 +556,19 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 	 * Cancel existing scheduled task for updating local Snapshot
 	 */
 	public static void terminateSnapshotAutoUpdateWorker() {
-		if (Objects.nonNull(scheduledExecutorService)) {
-			scheduledExecutorService.shutdownNow();
-			scheduledExecutorService = null;
+		if (Objects.nonNull(scheduledSnapshotExecutorService)) {
+			scheduledSnapshotExecutorService.shutdownNow();
+			scheduledSnapshotExecutorService = null;
+		}
+	}
+
+	/**
+	 * Cancel existing scheduled task for token refresh
+	 */
+	public static void terminateTokenRefreshWorker() {
+		if (Objects.nonNull(scheduledTokenExecutorService)) {
+			scheduledTokenExecutorService.shutdownNow();
+			scheduledTokenExecutorService = null;
 		}
 	}
 

--- a/src/main/java/com/switcherapi/client/SwitcherPropertiesImpl.java
+++ b/src/main/java/com/switcherapi/client/SwitcherPropertiesImpl.java
@@ -30,6 +30,7 @@ public class SwitcherPropertiesImpl implements SwitcherProperties {
 		setValue(ContextKey.LOCAL_MODE, false);
 		setValue(ContextKey.CHECK_SWITCHERS, false);
 		setValue(ContextKey.RESTRICT_RELAY, true);
+		setValue(ContextKey.AUTO_REFRESH_TOKEN, false);
 	}
 
 	@Override
@@ -49,6 +50,7 @@ public class SwitcherPropertiesImpl implements SwitcherProperties {
 		setValue(ContextKey.LOCAL_MODE, getBoolDefault(resolveProperties(ContextKey.LOCAL_MODE.getParam(), prop), false));
 		setValue(ContextKey.CHECK_SWITCHERS, getBoolDefault(resolveProperties(ContextKey.CHECK_SWITCHERS.getParam(), prop), false));
 		setValue(ContextKey.RESTRICT_RELAY, getBoolDefault(resolveProperties(ContextKey.RESTRICT_RELAY.getParam(), prop), true));
+		setValue(ContextKey.AUTO_REFRESH_TOKEN, getBoolDefault(resolveProperties(ContextKey.AUTO_REFRESH_TOKEN.getParam(), prop), false));
 		setValue(ContextKey.REGEX_TIMEOUT, getIntDefault(resolveProperties(ContextKey.REGEX_TIMEOUT.getParam(), prop), DEFAULT_REGEX_TIMEOUT));
 		setValue(ContextKey.TRUSTSTORE_PATH, resolveProperties(ContextKey.TRUSTSTORE_PATH.getParam(), prop));
 		setValue(ContextKey.TRUSTSTORE_PASSWORD, resolveProperties(ContextKey.TRUSTSTORE_PASSWORD.getParam(), prop));

--- a/src/main/java/com/switcherapi/client/model/ContextKey.java
+++ b/src/main/java/com/switcherapi/client/model/ContextKey.java
@@ -109,8 +109,13 @@ public enum ContextKey {
 	/**
 	 * (Number) Defines a fixed number of threads for the pool connection (default is 2).
 	 */
-	POOL_CONNECTION_SIZE("switcher.poolsize");
-	
+	POOL_CONNECTION_SIZE("switcher.poolsize"),
+
+	/**
+	 * (boolean) Enables automatic refresh of authentication token (default is false)
+	 */
+	AUTO_REFRESH_TOKEN("switcher.autorefreshtoken");
+
 	private final String param;
 	
 	ContextKey(String param) {

--- a/src/main/java/com/switcherapi/client/remote/dto/AuthResponse.java
+++ b/src/main/java/com/switcherapi/client/remote/dto/AuthResponse.java
@@ -26,6 +26,10 @@ public class AuthResponse {
 		return (this.exp * 1000) < System.currentTimeMillis();
 	}
 
+	public long getExp() {
+		return this.exp;
+	}
+
 	@Override
 	public String toString() {
 		return "AuthResponse{" +

--- a/src/main/java/com/switcherapi/client/service/WorkerName.java
+++ b/src/main/java/com/switcherapi/client/service/WorkerName.java
@@ -6,7 +6,8 @@ public enum WorkerName {
     SNAPSHOT_WATCH_WORKER("switcherapi-snapshot-watcher"),
     SNAPSHOT_UPDATE_WORKER("switcherapi-snapshot-update"),
     SWITCHER_REMOTE_WORKER("switcherapi-remote-pool"),
-    SWITCHER_ASYNC_WORKER("switcherapi-async");
+    SWITCHER_ASYNC_WORKER("switcherapi-async"),
+    SWITCHER_TOKEN_WORKER("switcherapi-token-refresh");
 
     private final String name;
 

--- a/src/main/java/com/switcherapi/client/service/remote/ClientRemoteService.java
+++ b/src/main/java/com/switcherapi/client/service/remote/ClientRemoteService.java
@@ -6,14 +6,24 @@ import com.switcherapi.client.exception.SwitcherInvalidDateTimeArgumentException
 import com.switcherapi.client.exception.SwitcherRemoteException;
 import com.switcherapi.client.model.ContextKey;
 import com.switcherapi.client.model.criteria.Snapshot;
-import com.switcherapi.client.remote.dto.*;
 import com.switcherapi.client.remote.ClientWS;
+import com.switcherapi.client.remote.dto.AuthResponse;
+import com.switcherapi.client.remote.dto.CriteriaRequest;
+import com.switcherapi.client.remote.dto.CriteriaResponse;
+import com.switcherapi.client.remote.dto.SnapshotVersionResponse;
+import com.switcherapi.client.remote.dto.SwitchersCheck;
 import com.switcherapi.client.utils.SwitcherUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Date;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Roger Floriano (petruki)
@@ -21,19 +31,27 @@ import java.util.Set;
  */
 public class ClientRemoteService implements ClientRemote {
 
+	private static final Logger log = LoggerFactory.getLogger(ClientRemoteService.class);
+
+	private final ScheduledExecutorService scheduledExecutorService;
+
 	private final SwitcherProperties switcherProperties;
-	
+
 	private final ClientWS clientWs;
 	
 	private AuthResponse authResponse;
+
+	private ScheduledFuture<?> refreshFuture;
 
 	private enum TokenStatus {
 		VALID, INVALID, SILENT
 	}
 	
-	public ClientRemoteService(ClientWS clientWs, SwitcherProperties switcherProperties) {
+	public ClientRemoteService(ClientWS clientWs, SwitcherProperties switcherProperties,
+							   ScheduledExecutorService scheduledExecutorService) {
 		this.clientWs = clientWs;
 		this.switcherProperties = switcherProperties;
+		this.scheduledExecutorService = scheduledExecutorService;
 	}
 
 	@Override
@@ -92,7 +110,12 @@ public class ClientRemoteService implements ClientRemote {
 
 	private void auth(TokenStatus tokenStatus) {
 		if (tokenStatus == TokenStatus.INVALID) {
+			log.debug("Auth token is invalid or expired. Attempting to authenticate...");
 			this.authResponse = this.clientWs.auth().orElseGet(AuthResponse::new);
+
+			if (isAutoRefreshable()) {
+				scheduleNextAuth();
+			}
 		}
 
 		if (tokenStatus == TokenStatus.SILENT) {
@@ -109,7 +132,7 @@ public class ClientRemoteService implements ClientRemote {
 			return TokenStatus.INVALID;
 		}
 
-		if (optAuthResponse.get().getToken().equals(ContextKey.SILENT_MODE.getParam())
+		if (ContextKey.SILENT_MODE.getParam().equals(optAuthResponse.get().getToken())
 				&& !optAuthResponse.get().isExpired()) {
 			return TokenStatus.SILENT;
 		}
@@ -129,4 +152,35 @@ public class ClientRemoteService implements ClientRemote {
 		}
 	}
 
+	private void scheduleNextAuth() {
+		long msUntilExpiry = (authResponse.getExp() * 1000L) - (System.currentTimeMillis());
+		long refreshAt = Math.max(msUntilExpiry - 5000, 0); // 5s before expiry
+
+		terminateAutoRefresh();
+		refreshFuture = scheduledExecutorService.schedule(() -> {
+			try {
+				log.debug("Auto-refreshing auth token...");
+				this.authResponse = this.clientWs.auth().orElseGet(AuthResponse::new);
+				scheduleNextAuth();
+			} catch (Exception e) {
+				log.error("Failed to auto-refresh auth token: {}", e.getMessage());
+				terminateAutoRefresh();
+			}
+		}, refreshAt, TimeUnit.MILLISECONDS);
+	}
+
+	private boolean isAutoRefreshable() {
+		return switcherProperties.getBoolean(ContextKey.AUTO_REFRESH_TOKEN) &&
+				(Objects.isNull(refreshFuture) || refreshFuture.isDone());
+	}
+
+	private void terminateAutoRefresh() {
+		if (Objects.nonNull(refreshFuture)) {
+			refreshFuture.cancel(true);
+			refreshFuture = null;
+			log.debug("Terminated existing auto-refresh task.");
+		}
+	}
 }
+
+

--- a/src/test/java/com/switcherapi/client/SwitcherBasicCriteriaResponseTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherBasicCriteriaResponseTest.java
@@ -24,7 +24,7 @@ class SwitcherBasicCriteriaResponseTest extends MockWebServerHelper {
 	
 	@BeforeAll
 	static void setup() throws IOException {
-		MockWebServerHelper.setupMockServer();
+		setupMockServer();
 
 		Switchers.loadProperties(); // Load default properties from resources
 		Switchers.configure(ContextBuilder.builder() // Override default properties
@@ -40,7 +40,7 @@ class SwitcherBasicCriteriaResponseTest extends MockWebServerHelper {
 	
 	@AfterAll
 	static void tearDown() {
-		MockWebServerHelper.tearDownMockServer();
+		tearDownMockServer();
     }
 	
 	@BeforeEach

--- a/src/test/java/com/switcherapi/client/SwitcherBasicTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherBasicTest.java
@@ -21,7 +21,7 @@ class SwitcherBasicTest extends MockWebServerHelper {
 	
 	@BeforeAll
 	static void setup() throws IOException {
-		MockWebServerHelper.setupMockServer();
+		setupMockServer();
 
 		Switchers.loadProperties(); // Load default properties from resources
 		Switchers.configure(ContextBuilder.builder() // Override default properties
@@ -37,7 +37,7 @@ class SwitcherBasicTest extends MockWebServerHelper {
 	
 	@AfterAll
 	static void tearDown() {
-		MockWebServerHelper.tearDownMockServer();
+		tearDownMockServer();
     }
 	
 	@BeforeEach

--- a/src/test/java/com/switcherapi/client/SwitcherConfigNativeTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherConfigNativeTest.java
@@ -16,12 +16,12 @@ class SwitcherConfigNativeTest extends MockWebServerHelper {
 
 	@BeforeAll
 	static void setup() throws IOException {
-		MockWebServerHelper.setupMockServer();
+		setupMockServer();
 	}
 
 	@AfterAll
 	static void tearDown() {
-		MockWebServerHelper.tearDownMockServer();
+		tearDownMockServer();
 	}
 
 	@Test

--- a/src/test/java/com/switcherapi/client/SwitcherContextRemoteExecutorTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherContextRemoteExecutorTest.java
@@ -18,12 +18,12 @@ class SwitcherContextRemoteExecutorTest extends MockWebServerHelper {
 
 	@BeforeAll
 	static void setup() throws IOException {
-		MockWebServerHelper.setupMockServer();
+		setupMockServer();
 	}
 
 	@AfterAll
 	static void tearDown() {
-		MockWebServerHelper.tearDownMockServer();
+		tearDownMockServer();
 	}
 
 	@Test

--- a/src/test/java/com/switcherapi/client/SwitcherFail1Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherFail1Test.java
@@ -21,7 +21,7 @@ class SwitcherFail1Test extends MockWebServerHelper {
 	
 	@BeforeAll
 	static void setup() throws IOException {
-		MockWebServerHelper.setupMockServer();
+		setupMockServer();
         
         Switchers.loadProperties();
         Switchers.configure(ContextBuilder.builder().url(String.format("http://localhost:%s", mockBackEnd.getPort())));
@@ -30,7 +30,7 @@ class SwitcherFail1Test extends MockWebServerHelper {
 	
 	@AfterAll
 	static void tearDown() {
-		MockWebServerHelper.tearDownMockServer();
+		tearDownMockServer();
         
         //clean generated outputs
     	SwitcherContext.stopWatchingSnapshot();

--- a/src/test/java/com/switcherapi/client/SwitcherFail2Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherFail2Test.java
@@ -21,7 +21,7 @@ class SwitcherFail2Test extends MockWebServerHelper {
 	
 	@BeforeAll
 	static void setup() throws IOException {
-		MockWebServerHelper.setupMockServer();
+		setupMockServer();
 
 		Switchers.loadProperties();
 		Switchers.configure(ContextBuilder.builder().url(String.format("http://localhost:%s", mockBackEnd.getPort())));
@@ -30,7 +30,7 @@ class SwitcherFail2Test extends MockWebServerHelper {
 	
 	@AfterAll
 	static void tearDown() {
-		MockWebServerHelper.tearDownMockServer();
+		tearDownMockServer();
     }
 	
 	@BeforeEach

--- a/src/test/java/com/switcherapi/client/SwitcherForceResolveTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherForceResolveTest.java
@@ -1,6 +1,6 @@
 package com.switcherapi.client;
 
-import com.switcherapi.Switchers;
+import com.switcherapi.SwitchersBase;
 import com.switcherapi.client.model.SwitcherRequest;
 import com.switcherapi.fixture.MockWebServerHelper;
 import mockwebserver3.QueueDispatcher;
@@ -19,10 +19,13 @@ class SwitcherForceResolveTest extends MockWebServerHelper {
 	
 	@BeforeAll
 	static void setup() throws IOException {
-		MockWebServerHelper.setupMockServer();
+		setupMockServer();
 
-		Switchers.loadProperties(); // Load default properties from resources
-		Switchers.configure(ContextBuilder.builder() // Override default properties
+		SwitchersBase.configure(ContextBuilder.builder(true) // Override default properties
+				.context(SwitchersBase.class.getName())
+				.domain("domain")
+				.apiKey("apiKey")
+				.component("component")
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
 				.local(true)
 				.snapshotLocation(SNAPSHOTS_LOCAL)
@@ -31,12 +34,12 @@ class SwitcherForceResolveTest extends MockWebServerHelper {
 				.snapshotAutoUpdateInterval(null)
 				.environment("fixture1"));
 
-        Switchers.initializeClient();
+		SwitchersBase.initializeClient();
     }
 	
 	@AfterAll
 	static void tearDown() {
-		MockWebServerHelper.tearDownMockServer();
+		tearDownMockServer();
     }
 	
 	@BeforeEach
@@ -46,7 +49,7 @@ class SwitcherForceResolveTest extends MockWebServerHelper {
 
 	@Test
 	void shouldResolveLocally() {
-		SwitcherRequest switcher = Switchers.getSwitcher(Switchers.USECASE11);
+		SwitcherRequest switcher = SwitchersBase.getSwitcher(SwitchersBase.USECASE11);
 		assertTrue(switcher.remote(false).isItOn());
 	}
 	
@@ -59,7 +62,7 @@ class SwitcherForceResolveTest extends MockWebServerHelper {
 		givenResponse(generateCriteriaResponse("false", false));
 		
 		//test
-		SwitcherRequest switcher = Switchers.getSwitcher(Switchers.USECASE11);
+		SwitcherRequest switcher = SwitchersBase.getSwitcher(SwitchersBase.USECASE11);
 		assertFalse(switcher.remote(true).isItOn());
 	}
 

--- a/src/test/java/com/switcherapi/client/SwitcherLocal3Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherLocal3Test.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Stream;
 
 import com.switcherapi.client.remote.ClientWS;
@@ -40,10 +41,13 @@ class SwitcherLocal3Test {
 	private static final String SNAPSHOTS_LOCAL = Paths.get(StringUtils.EMPTY).toAbsolutePath() + "/src/test/resources/snapshot";
 
 	private static ExecutorService executorService;
+
+	private static ScheduledExecutorService scheduledExecutorService;
 	
 	@BeforeAll
 	static void setupContext() {
 		executorService = Executors.newSingleThreadExecutor();
+		scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 		SwitcherContext.loadProperties();
 		SwitcherContext.configure(ContextBuilder.builder()
 				.snapshotLocation(SNAPSHOTS_LOCAL)
@@ -56,6 +60,7 @@ class SwitcherLocal3Test {
 	@AfterAll
 	static void tearDown() {
 		executorService.shutdown();
+		scheduledExecutorService.shutdownNow();
 	}
 	
 	static Stream<Arguments> failTestArguments() {
@@ -96,7 +101,7 @@ class SwitcherLocal3Test {
 		ClientWS clientWS = ClientWSImpl.build(switcherProperties, executorService, DEFAULT_TIMEOUT);
 		SwitcherValidator validatorService = new ValidatorService();
 		SwitcherLocalService switcherLocal = new SwitcherLocalService(
-				new ClientRemoteService(clientWS, switcherProperties),
+				new ClientRemoteService(clientWS, switcherProperties, scheduledExecutorService),
 				new ClientLocalService(validatorService), switcherProperties);
 		switcherLocal.init();
 		
@@ -114,7 +119,7 @@ class SwitcherLocal3Test {
 		ClientWS clientWS = ClientWSImpl.build(switcherProperties, executorService, DEFAULT_TIMEOUT);
 		SwitcherValidator validatorService = new ValidatorService();
 		SwitcherLocalService switcherLocal = new SwitcherLocalService(
-				new ClientRemoteService(clientWS, switcherProperties),
+				new ClientRemoteService(clientWS, switcherProperties, scheduledExecutorService),
 				new ClientLocalService(validatorService), switcherProperties);
 		switcherLocal.init();
 		

--- a/src/test/java/com/switcherapi/client/SwitcherRemoteAutoRefreshTokenTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherRemoteAutoRefreshTokenTest.java
@@ -1,0 +1,98 @@
+package com.switcherapi.client;
+
+import com.switcherapi.SwitchersBase;
+import com.switcherapi.client.exception.SwitcherRemoteException;
+import com.switcherapi.client.model.SwitcherRequest;
+import com.switcherapi.fixture.CountDownHelper;
+import com.switcherapi.fixture.MockWebServerHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SwitcherRemoteAutoRefreshTokenTest extends MockWebServerHelper {
+
+	@BeforeEach
+	void setup() throws IOException {
+		setupMockServer();
+	}
+
+	@AfterEach
+	void tearDown() {
+		tearDownMockServer();
+		SwitchersBase.terminateTokenRefreshWorker();
+	}
+
+	/**
+	 * The scheduled refresh worker operates using a 5s buffer to trigger the refresh before the token expires,
+	 * so we need to set the token expiration time accordingly to test the auto-refresh behavior.
+	 */
+	@Test
+	void shouldAutoRefreshAuthToken() {
+		//auth - 1st (regular auth) - 2nd (scheduled refresh)
+		givenResponse(generateMockAuth(7)); // 5s buffer - 7s exp = 2s for async refresh
+		givenResponse(generateCriteriaResponse("true", false));
+		givenResponse(generateMockAuth(60));
+		givenResponse(generateCriteriaResponse("true", false));
+
+		//when
+		givenAutoRefreshToken(true);
+
+		//test
+		SwitcherRequest switcher = SwitchersBase.getSwitcher(SwitchersBase.USECASE11);
+		assertTrue(switcher.isItOn());
+		CountDownHelper.wait(2);
+		assertTrue(switcher.isItOn());
+	}
+
+	@Test
+	void shouldNotAutoRefreshAuthTokenWhenDisabled() {
+		//auth - 1st (regular auth) - 2nd (regular auth)
+		givenResponse(generateMockAuth(1));
+		givenResponse(generateCriteriaResponse("true", false));
+		givenResponse(generateMockAuth(60));
+		givenResponse(generateCriteriaResponse("true", false));
+
+		//when
+		givenAutoRefreshToken(false);
+
+		//test
+		SwitcherRequest switcher = SwitchersBase.getSwitcher(SwitchersBase.USECASE11);
+		assertTrue(switcher.isItOn());
+		CountDownHelper.wait(1);
+		assertTrue(switcher.isItOn());
+	}
+
+	@Test
+	void shouldNotAutoRefreshAuthTokenWhenAuthFails() {
+		//auth - 1st (regular auth) - 2nd (scheduled refresh)
+		givenResponse(generateMockAuth(7)); // 5s buffer - 6s exp = 1s for async refresh
+		givenResponse(generateCriteriaResponse("true", false));
+		givenResponse(generateStatusResponse("500"));
+
+		//when
+		givenAutoRefreshToken(true);
+
+		//test
+		SwitcherRequest switcher = SwitchersBase.getSwitcher(SwitchersBase.USECASE11);
+		assertTrue(switcher.isItOn());
+		CountDownHelper.wait(2);
+		assertThrows(SwitcherRemoteException.class, switcher::isItOn);
+	}
+
+	private void givenAutoRefreshToken(boolean enabled) {
+		SwitchersBase.configure(ContextBuilder.builder(true)
+				.context(SwitchersBase.class.getName())
+				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
+				.domain("domain")
+				.apiKey("apiKey")
+				.component("component")
+				.autoRefreshToken(enabled));
+
+		SwitchersBase.initializeClient();
+	}
+}

--- a/src/test/java/com/switcherapi/client/SwitcherSilentModeTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSilentModeTest.java
@@ -23,7 +23,7 @@ class SwitcherSilentModeTest extends MockWebServerHelper {
 	
 	@BeforeAll
 	static void setup() throws IOException {
-		MockWebServerHelper.setupMockServer();
+		setupMockServer();
         
         Switchers.loadProperties();
         Switchers.configure(ContextBuilder.builder().url(String.format("http://localhost:%s", mockBackEnd.getPort())));
@@ -31,7 +31,7 @@ class SwitcherSilentModeTest extends MockWebServerHelper {
 	
 	@AfterAll
 	static void tearDown() {
-		MockWebServerHelper.tearDownMockServer();
+		tearDownMockServer();
     }
 	
 	@BeforeEach

--- a/src/test/java/com/switcherapi/client/SwitcherSnapshotLookupTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSnapshotLookupTest.java
@@ -28,7 +28,7 @@ class SwitcherSnapshotLookupTest extends MockWebServerHelper {
 		Files.deleteIfExists(Paths.get(RESOURCES_PATH + "/new_folder"));
 		Files.deleteIfExists(Paths.get(RESOURCES_PATH + "/generated_mock_default.json"));
 
-		MockWebServerHelper.setupMockServer();
+		setupMockServer();
 
 		Switchers.loadProperties();
 		Switchers.configure(ContextBuilder.builder().url(String.format("http://localhost:%s", mockBackEnd.getPort())));
@@ -36,7 +36,7 @@ class SwitcherSnapshotLookupTest extends MockWebServerHelper {
 
 	@AfterAll
 	static void tearDown() throws IOException {
-		MockWebServerHelper.tearDownMockServer();
+		tearDownMockServer();
 
 		//clean generated outputs
 		SwitcherContext.stopWatchingSnapshot();

--- a/src/test/java/com/switcherapi/client/SwitcherSnapshotValidationFailTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSnapshotValidationFailTest.java
@@ -25,7 +25,7 @@ class SwitcherSnapshotValidationFailTest extends MockWebServerHelper {
 	static void setup() throws IOException {
 		Files.deleteIfExists(Paths.get(RESOURCES_PATH + "/not_accessible"));
 
-		MockWebServerHelper.setupMockServer();
+		setupMockServer();
         
         Switchers.loadProperties();
         Switchers.configure(ContextBuilder.builder().url(String.format("http://localhost:%s", mockBackEnd.getPort())));
@@ -33,7 +33,7 @@ class SwitcherSnapshotValidationFailTest extends MockWebServerHelper {
 	
 	@AfterAll
 	static void tearDown() {
-		MockWebServerHelper.tearDownMockServer();
+		tearDownMockServer();
         
         //clean generated outputs
     	SwitcherContext.stopWatchingSnapshot();

--- a/src/test/java/com/switcherapi/client/SwitcherSnapshotValidationTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSnapshotValidationTest.java
@@ -22,7 +22,7 @@ class SwitcherSnapshotValidationTest extends MockWebServerHelper {
 	
 	@BeforeAll
 	static void setup() throws IOException {
-		MockWebServerHelper.setupMockServer();
+		setupMockServer();
         
         Switchers.loadProperties();
         Switchers.configure(ContextBuilder.builder().url(String.format("http://localhost:%s", mockBackEnd.getPort())));
@@ -30,7 +30,7 @@ class SwitcherSnapshotValidationTest extends MockWebServerHelper {
 	
 	@AfterAll
 	static void tearDown() {
-		MockWebServerHelper.tearDownMockServer();
+		tearDownMockServer();
         
         //clean generated outputs
     	SwitcherContext.stopWatchingSnapshot();

--- a/src/test/java/com/switcherapi/client/SwitcherThrottle1Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherThrottle1Test.java
@@ -18,7 +18,7 @@ class SwitcherThrottle1Test extends MockWebServerHelper {
 	
 	@BeforeAll
 	static void setup() throws IOException {
-		MockWebServerHelper.setupMockServer();
+		setupMockServer();
 
 		SwitchersBase.configure(ContextBuilder.builder(true)
 				.context(SwitchersBase.class.getName())
@@ -33,7 +33,7 @@ class SwitcherThrottle1Test extends MockWebServerHelper {
 	
 	@AfterAll
 	static void tearDown() {
-		MockWebServerHelper.tearDownMockServer();
+		tearDownMockServer();
     }
 	
 	@Test
@@ -54,7 +54,7 @@ class SwitcherThrottle1Test extends MockWebServerHelper {
 				.checkValue("value")
 				.throttle(1000);
 		
-		for (int i = 0; i < 100; i++) {
+		for (int i = 0; i < 50; i++) {
 			assertTrue(switcher.isItOn());
 		}
 

--- a/src/test/java/com/switcherapi/client/SwitcherThrottle2Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherThrottle2Test.java
@@ -17,7 +17,7 @@ class SwitcherThrottle2Test extends MockWebServerHelper {
 	
 	@BeforeAll
 	static void setup() throws IOException {
-		MockWebServerHelper.setupMockServer();
+		setupMockServer();
 
 		SwitchersBase.configure(ContextBuilder.builder(true)
 				.context(SwitchersBase.class.getName())
@@ -32,7 +32,7 @@ class SwitcherThrottle2Test extends MockWebServerHelper {
 	
 	@AfterAll
 	static void tearDown() {
-		MockWebServerHelper.tearDownMockServer();
+		tearDownMockServer();
     }
 
 	@Test

--- a/src/test/java/com/switcherapi/client/SwitcherValidateTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherValidateTest.java
@@ -20,7 +20,7 @@ class SwitcherValidateTest extends MockWebServerHelper {
 
 	@BeforeAll
 	static void setup() throws IOException {
-		MockWebServerHelper.setupMockServer();
+		setupMockServer();
         
         Switchers.loadProperties();
         Switchers.configure(ContextBuilder.builder().url(String.format("http://localhost:%s", mockBackEnd.getPort())));
@@ -29,7 +29,7 @@ class SwitcherValidateTest extends MockWebServerHelper {
 	
 	@AfterAll
 	static void tearDown() {
-		MockWebServerHelper.tearDownMockServer();
+		tearDownMockServer();
         
         //clean generated outputs
     	SwitcherContext.stopWatchingSnapshot();

--- a/src/test/java/com/switcherapi/client/remote/ClientRemoteTest.java
+++ b/src/test/java/com/switcherapi/client/remote/ClientRemoteTest.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static com.switcherapi.client.remote.Constants.DEFAULT_TIMEOUT;
 import static org.junit.jupiter.api.Assertions.*;
@@ -37,12 +38,15 @@ class ClientRemoteTest extends MockWebServerHelper {
 
     private static ExecutorService executorService;
 
+    private static ScheduledExecutorService scheduledExecutorService;
+
     private ClientRemote clientRemote;
 
     @BeforeAll
     static void setup() throws IOException {
         executorService = Executors.newSingleThreadExecutor();
-        MockWebServerHelper.setupMockServer();
+        scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        setupMockServer();
 
         Switchers.loadProperties();
         Switchers.configure(ContextBuilder.builder().url(String.format("http://localhost:%s", mockBackEnd.getPort())));
@@ -51,14 +55,16 @@ class ClientRemoteTest extends MockWebServerHelper {
 
     @AfterAll
     static void tearDown() {
-        MockWebServerHelper.tearDownMockServer();
+        tearDownMockServer();
         executorService.shutdown();
+        scheduledExecutorService.shutdownNow();
     }
 
     @BeforeEach
     void resetSwitcherContextState() {
         SwitcherProperties switcherProperties = Switchers.getSwitcherProperties();
-        clientRemote = new ClientRemoteService(ClientWSImpl.build(switcherProperties, executorService, DEFAULT_TIMEOUT), switcherProperties);
+        clientRemote = new ClientRemoteService(ClientWSImpl.build(switcherProperties, executorService, DEFAULT_TIMEOUT),
+                switcherProperties, scheduledExecutorService);
         ((QueueDispatcher) mockBackEnd.getDispatcher()).clear();
 
         Switchers.configure(ContextBuilder.builder().checkSwitchers(false));

--- a/src/test/java/com/switcherapi/client/remote/ClientWSBuilderTest.java
+++ b/src/test/java/com/switcherapi/client/remote/ClientWSBuilderTest.java
@@ -32,14 +32,14 @@ class ClientWSBuilderTest {
 
     @Test
     void shouldCreateClientBuilder() {
-        // given
+        //given
         SwitcherContextBase.configure(ContextBuilder.builder()
                 .truststorePath("")
                 .truststorePassword(""));
 
         SwitcherProperties properties = SwitcherContextBase.getSwitcherProperties();
 
-        // test
+        //test
         ClientBuilder clientBuilder = ClientWSBuilder.builder(executorService, properties);
         assertNotNull(clientBuilder);
 
@@ -50,7 +50,7 @@ class ClientWSBuilderTest {
 
     @Test
     void shouldCreateClientBuilderSSL() {
-        // given
+        //given
         String truststorePath = Objects.requireNonNull(getClass().getClassLoader()
                 .getResource("keystore.jks")).getPath();
 
@@ -60,7 +60,7 @@ class ClientWSBuilderTest {
 
         SwitcherProperties properties = SwitcherContextBase.getSwitcherProperties();
 
-        // test
+        //test
         ClientBuilder clientBuilder = ClientWSBuilder.builder(executorService, properties);
         assertNotNull(clientBuilder);
 
@@ -71,7 +71,7 @@ class ClientWSBuilderTest {
 
     @Test
     void shouldNotCreateClientBuilderSSL_invalidKeystorePassword() {
-        // given
+        //given
         String truststorePath = Objects.requireNonNull(getClass().getClassLoader()
                 .getResource("keystore.jks")).getPath();
 
@@ -81,20 +81,20 @@ class ClientWSBuilderTest {
 
         SwitcherProperties properties = SwitcherContextBase.getSwitcherProperties();
 
-        // test
+        //test
         assertThrows(SwitcherException.class, () -> ClientWSBuilder.builder(executorService, properties));
     }
 
     @Test
     void shouldNotCreateClientBuilderSSL_invalidKeystorePath() {
-        // given
+        //given
         SwitcherContextBase.configure(ContextBuilder.builder()
                 .truststorePath("INVALID")
                 .truststorePassword("changeit"));
 
         SwitcherProperties properties = SwitcherContextBase.getSwitcherProperties();
 
-        // test
+        //test
         assertThrows(SwitcherException.class, () -> ClientWSBuilder.builder(executorService, properties));
     }
 }

--- a/src/test/java/com/switcherapi/client/remote/ClientWSTest.java
+++ b/src/test/java/com/switcherapi/client/remote/ClientWSTest.java
@@ -24,7 +24,7 @@ class ClientWSTest extends MockWebServerHelper {
     @BeforeAll
     static void setup() throws IOException {
         executorService = Executors.newSingleThreadExecutor();
-        MockWebServerHelper.setupMockServer();
+        setupMockServer();
 
         Switchers.loadProperties();
         Switchers.configure(ContextBuilder.builder().url(String.format("http://localhost:%s", mockBackEnd.getPort())));
@@ -33,7 +33,7 @@ class ClientWSTest extends MockWebServerHelper {
 
     @AfterAll
     static void tearDown() {
-        MockWebServerHelper.tearDownMockServer();
+        tearDownMockServer();
         executorService.shutdown();
     }
 
@@ -47,22 +47,22 @@ class ClientWSTest extends MockWebServerHelper {
 
     @Test
     void shouldBeAlive() {
-        // given
+        //given
         ClientWS clientWS = ClientWSImpl.build(Switchers.getSwitcherProperties(), executorService, DEFAULT_TIMEOUT);
         givenResponse(generateTimeOut(100));
 
-        // test
+        //test
         boolean response = clientWS.isAlive();
         assertTrue(response);
     }
 
     @Test
     void shouldTimeOut() {
-        // given
+        //given
         ClientWS clientWS = ClientWSImpl.build(Switchers.getSwitcherProperties(), executorService, DEFAULT_TIMEOUT);
         givenResponse(generateTimeOut(3500));
 
-        // test
+        //test
         boolean response = clientWS.isAlive();
         assertFalse(response);
     }
@@ -72,7 +72,7 @@ class ClientWSTest extends MockWebServerHelper {
         ClientWS clientWS = ClientWSImpl.build(Switchers.getSwitcherProperties(), executorService, 4000);
         givenResponse(generateTimeOut(3500));
 
-        // test
+        //test
         boolean response = clientWS.isAlive();
         assertTrue(response);
     }

--- a/src/test/java/com/switcherapi/client/service/local/SwitcherLocalServiceTest.java
+++ b/src/test/java/com/switcherapi/client/service/local/SwitcherLocalServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Paths;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.switcherapi.client.SwitcherProperties;
@@ -31,12 +32,15 @@ class SwitcherLocalServiceTest {
 	private static final String SNAPSHOTS_LOCAL = Paths.get(StringUtils.EMPTY).toAbsolutePath() + "/src/test/resources";
 
 	private static ExecutorService executorService;
+
+	private static ScheduledExecutorService scheduledExecutorService;
 	
 	private static SwitcherLocalService service;
 	
 	@BeforeAll
 	static void init() {
 		executorService = Executors.newSingleThreadExecutor();
+		scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 		SwitchersBase.configure(ContextBuilder.builder()
 				.context(SwitchersBase.class.getName())
 				.snapshotLocation(SNAPSHOTS_LOCAL)
@@ -47,13 +51,14 @@ class SwitcherLocalServiceTest {
 		ClientWS clientWS = ClientWSImpl.build(properties, executorService, DEFAULT_TIMEOUT);
 		SwitcherValidator validatorService = new ValidatorService();
 		service = new SwitcherLocalService(
-				new ClientRemoteService(clientWS, properties),
+				new ClientRemoteService(clientWS, properties, scheduledExecutorService),
 				new ClientLocalService(validatorService), properties);
 	}
 
 	@AfterAll
 	static void tearDown() {
 		executorService.shutdown();
+		scheduledExecutorService.shutdownNow();
 	}
 
 	@Test

--- a/src/test/java/com/switcherapi/playground/ClientPlayground.java
+++ b/src/test/java/com/switcherapi/playground/ClientPlayground.java
@@ -19,18 +19,16 @@ public class ClientPlayground {
 
 	public static void test() {
 		new Features().configureClient();
-		Switcher switcher = getSwitcher(CLIENT_JAVA_FEATURE)
-				.bypassMetrics();
+		Switcher switcher = getSwitcher(CLIENT_JAVA_FEATURE).bypassMetrics();
 
 		scheduler.scheduleAtFixedRate(() -> {
 			try {
 				long time = System.currentTimeMillis();
-				logger.info("Switcher is on: {}", switcher.isItOn());
-				logger.info("Time elapsed: {}", System.currentTimeMillis() - time);
+				logger.info("Switcher is on: {} - {} ms", switcher.isItOn(), System.currentTimeMillis() - time);
 			} catch (Exception e) {
 				logger.error(e.getMessage(), e);
 			}
-		}, 0, 5, TimeUnit.SECONDS);
+		}, 0, 500, TimeUnit.MILLISECONDS);
 	}
 
 	public static void main(String[] args) {

--- a/src/test/java/com/switcherapi/playground/Features.java
+++ b/src/test/java/com/switcherapi/playground/Features.java
@@ -13,12 +13,11 @@ public class Features extends SwitcherContextBase {
 	protected void configureClient() {
 		configure(ContextBuilder.builder()
 				.context(Features.class.getName())
-				.url("https://api.switcherapi.com")
+				.url("http://localhost:3001")
 				.apiKey(System.getenv("switcher.api.key"))
 				.component(System.getenv("switcher.component"))
 				.domain(System.getenv("switcher.domain"))
-				.local(true)
-				.snapshotLocation("./src/test/resources/snapshot/playground"));
+				.autoRefreshToken(true));
 
 		initializeClient();
 	}


### PR DESCRIPTION
This pull request introduces a new feature for automatic authentication token refresh in the Switcher client, along with supporting infrastructure and minor code improvements. The main focus is on enabling the client to automatically refresh its API token before expiration, improving reliability for long-running applications. Additionally, there are some refactorings to executor management and test code cleanup.

**New Feature: Automatic Token Refresh**

* Added support for the `switcher.autorefreshtoken` property, allowing the client to automatically refresh the API token before expiration. This includes updates to the configuration, builder, and property handling (`README.md`, `SwitcherConfig.java`, `ContextBuilder.java`, `SwitcherPropertiesImpl.java`, `ContextKey.java`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R148) [[2]](diffhunk://#diff-f4798b3f30b7930015f604f15c3c9b98ae890b4b1e43a0fa57a420d95fdf83f7R15) [[3]](diffhunk://#diff-7c11d00cf0b6eb4221f0b4fb20ed1b75c6cf7368f0728ac550de45df9f428aacR249-R253) [[4]](diffhunk://#diff-737ab0c47382c06d0aa246b759aeed87a3ac67df7e0bb922ef81fcc1f89a206dR33) [[5]](diffhunk://#diff-737ab0c47382c06d0aa246b759aeed87a3ac67df7e0bb922ef81fcc1f89a206dR53) [[6]](diffhunk://#diff-9d69e6a43207632080271a836627e90ccf57b507abb6b24234473aeb940d60bfL112-R117)

* Implemented a scheduled executor service and logic in `ClientRemoteService` to handle token refresh, including scheduling, cancellation, and error handling. The service schedules a token refresh shortly before expiry if auto-refresh is enabled (`ClientRemoteService.java`, `SwitcherContextBase.java`, `WorkerName.java`). [[1]](diffhunk://#diff-7c65cdea5f64f933d93793317683b73c719447a0ccbdec5211be8d8b955bade7L9-R54) [[2]](diffhunk://#diff-7c65cdea5f64f933d93793317683b73c719447a0ccbdec5211be8d8b955bade7R113-R118) [[3]](diffhunk://#diff-7c65cdea5f64f933d93793317683b73c719447a0ccbdec5211be8d8b955bade7R155-R186) [[4]](diffhunk://#diff-58fea277cde9b83cbb7929cce8f315b3577b69c0b7f98a82273c85e8a77d616eL90-R91) [[5]](diffhunk://#diff-58fea277cde9b83cbb7929cce8f315b3577b69c0b7f98a82273c85e8a77d616eR116) [[6]](diffhunk://#diff-58fea277cde9b83cbb7929cce8f315b3577b69c0b7f98a82273c85e8a77d616eR203-R208) [[7]](diffhunk://#diff-58fea277cde9b83cbb7929cce8f315b3577b69c0b7f98a82273c85e8a77d616eL343-R370) [[8]](diffhunk://#diff-58fea277cde9b83cbb7929cce8f315b3577b69c0b7f98a82273c85e8a77d616eL542-R571) [[9]](diffhunk://#diff-fc72506149a66bb91f459ceba7a0a1ccdc3a35791087c10cc715d51fa16a6076L9-R10)

**Executor Service and Refactoring**

* Refactored snapshot and token refresh executor management for clarity and separation of concerns, including new executor fields, initialization methods, and termination logic in `SwitcherContextBase` and related files. [[1]](diffhunk://#diff-58fea277cde9b83cbb7929cce8f315b3577b69c0b7f98a82273c85e8a77d616eL90-R91) [[2]](diffhunk://#diff-58fea277cde9b83cbb7929cce8f315b3577b69c0b7f98a82273c85e8a77d616eL310-R315) [[3]](diffhunk://#diff-58fea277cde9b83cbb7929cce8f315b3577b69c0b7f98a82273c85e8a77d616eL328-R333) [[4]](diffhunk://#diff-58fea277cde9b83cbb7929cce8f315b3577b69c0b7f98a82273c85e8a77d616eL343-R370) [[5]](diffhunk://#diff-58fea277cde9b83cbb7929cce8f315b3577b69c0b7f98a82273c85e8a77d616eL542-R571)

**Configuration and Documentation**

* Updated the `README.md` to document the new `switcher.autorefreshtoken` property and fixed a minor formatting issue in the configuration table. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L139-R139) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R148)

* Bumped the project version to `1.10.0-SNAPSHOT` in `pom.xml`.

**Testing and Minor Fixes**

* Simplified test setup and teardown methods by calling helper methods directly, improving readability in several test classes. [[1]](diffhunk://#diff-1637d741bf06576210932de03cfd3051e896beafa7cdeb07bb977f1f84c1c3beL27-R27) [[2]](diffhunk://#diff-1637d741bf06576210932de03cfd3051e896beafa7cdeb07bb977f1f84c1c3beL43-R43) [[3]](diffhunk://#diff-3d8fc35838bbce9ed2e039cdb404eeeee57d575f3f7c0b2416a4a4e1baafc1feL24-R24) [[4]](diffhunk://#diff-3d8fc35838bbce9ed2e039cdb404eeeee57d575f3f7c0b2416a4a4e1baafc1feL40-R40) [[5]](diffhunk://#diff-6fc7b32e3a7874348da82f2337939679aadf0dd8277fad4c46b1e5d52064d3cdL19-R24)

* Added a getter for the `exp` field in `AuthResponse` to support the token refresh logic.

**Other Improvements**

* Minor bug fix in token validation logic to ensure correct silent mode handling.