### PR TITLE
patch: vulnerability introduced through jackson.core WS-2026-0003

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 		<!-- utils -->
 		<commons-lang3.version>3.20.0</commons-lang3.version>
 		<commons-net.version>3.13.0</commons-net.version>
-		<slf4j-api.version>2.0.17</slf4j-api.version>
+		<slf4j-api.version>2.0.18</slf4j-api.version>
 
 		<!-- test -->
 		<okhttp.version>5.3.2</okhttp.version>
@@ -183,6 +183,27 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<dependencyManagement>
+		<dependencies>
+			<!-- Pin jackson.core: patch WS-2026-0003 Transitive Insufficient Information Vulnerability -->
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-core</artifactId>
+				<version>2.21.3</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>2.21.3</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-annotations</artifactId>
+				<version>2.21</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<profiles>
 		<profile>


### PR DESCRIPTION
This pull request updates dependencies in the `pom.xml` to address security and stability concerns. The main changes are the upgrade of the `slf4j-api` version and the addition of a `dependencyManagement` section to pin specific versions of Jackson libraries, which helps mitigate a known vulnerability.

Dependency updates and security improvements:

* Upgraded the `slf4j-api` dependency from version `2.0.17` to `2.0.18` to ensure the latest fixes and improvements are included.

* Added a `dependencyManagement` section to explicitly pin the versions of the Jackson core libraries (`jackson-core`, `jackson-databind`, and `jackson-annotations`) to address vulnerability WS-2026-0003 and ensure consistent dependency resolution across the project.