### PR TITLE
chore(tests): updated timed tests and other code smells

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ Create `src/main/resources/switcherapi.properties`:
 # Required Configuration
 switcher.context=com.example.MyAppFeatures
 switcher.url=https://api.switcherapi.com
-switcher.apikey=YOUR_API_KEY
-switcher.component=my-application
-switcher.domain=MY_DOMAIN
+switcher.apikey=[API_KEY]
+switcher.component=[COMPONENT_NAME]
+switcher.domain=[DOMAIN_NAME}
 
 # Optional Configuration
 switcher.environment=default
@@ -188,10 +188,10 @@ public class MyAppFeatures extends SwitcherContextBase {
     static {
         configure(ContextBuilder.builder()
             .context(MyAppFeatures.class.getName())
-            .apiKey("YOUR_API_KEY")
+            .apiKey("[API_KEY]")
             .url("https://api.switcherapi.com")
-            .domain("MY_DOMAIN")
-            .component("my-application")
+            .domain("[DOMAIN_NAME]")
+            .component("[COMPONENT_NAME]")
             .environment("default"));
         
         initializeClient();
@@ -337,9 +337,9 @@ Default mode that communicates directly with Switcher API.
 ```java
 MyAppFeatures.configure(ContextBuilder.builder()
     .url("https://api.switcherapi.com")
-    .apiKey("YOUR_API_KEY")
-    .domain("MY_DOMAIN")
-    .component("my-app"));
+    .apiKey("[API_KEY]")
+    .domain("[DOMAIN_NAME]")
+    .component("[COMPONENT_NAME]"));
 
 MyAppFeatures.initializeClient();
 ```
@@ -382,12 +382,12 @@ switcher.forceRemote().isItOn();
 ```java
 MyAppFeatures.configure(ContextBuilder.builder()
     .url("https://api.switcherapi.com")
-    .apiKey("YOUR_API_KEY")
-    .domain("MY_DOMAIN")
+    .apiKey("[API_KEY]")
+    .domain("[DOMAIN_NAME]")
     .local(true)
     .snapshotAutoLoad(true)
     .snapshotAutoUpdateInterval("30s")  // Check for updates every 30 seconds
-    .component("my-app"));
+    .component("[COMPONENT_NAME]"));
 
 MyAppFeatures.initializeClient();
 
@@ -418,10 +418,10 @@ Here is an example - in-memory snapshot with auto-update every 30 seconds:
 ```java
 MyAppFeatures.configure(ContextBuilder.builder()
     .context(MyAppFeatures.class.getName())
-    .apiKey("YOUR_API_KEY")
+    .apiKey("[API_KEY]")
     .url("https://api.switcherapi.com")
-    .domain("MY_DOMAIN")
-    .component("my-application")
+    .domain("[DOMAIN_NAME")
+    .component("[COMPONENT_NAME]")
     .silentMode("5m")
     .snapshotAutoUpdateInterval("30s")
 );

--- a/src/main/java/com/switcherapi/client/SwitcherContextBase.java
+++ b/src/main/java/com/switcherapi/client/SwitcherContextBase.java
@@ -66,10 +66,9 @@ import static com.switcherapi.client.remote.Constants.DEFAULT_TIMEOUT;
  * public void configureClient() {
  *  	Features.configure(ContextBuilder.builder()
  *   		.context(Features.class.getName())
- *   		.apiKey("API_KEY")
- *   		.domain("Playground")
- *   		.component("switcher-playground")
- *   		.environment("default"));
+ *   		.apiKey("[API_KEY]")
+ *   		.domain("[DOMAIN_NAME]")
+ *   		.component("[COMPONENT_NAME]"));
  *
  *  	Features.initializeClient();
  * }

--- a/src/test/java/com/switcherapi/client/SwitcherBasicCriteriaResponseTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherBasicCriteriaResponseTest.java
@@ -1,6 +1,6 @@
 package com.switcherapi.client;
 
-import com.switcherapi.Switchers;
+import com.switcherapi.SwitchersBase;
 import com.switcherapi.client.model.SwitcherBuilder;
 import com.switcherapi.client.model.SwitcherRequest;
 import com.switcherapi.client.model.SwitcherResult;
@@ -21,33 +21,30 @@ import static org.junit.jupiter.api.Assertions.*;
 class SwitcherBasicCriteriaResponseTest extends MockWebServerHelper {
 
 	private boolean authTokenGenerated = false;
-	
+
 	@BeforeAll
 	static void setup() throws IOException {
 		setupMockServer();
 
-		Switchers.loadProperties(); // Load default properties from resources
-		Switchers.configure(ContextBuilder.builder() // Override default properties
+		SwitchersBase.configure(ContextBuilder.builder(true)
+				.context(SwitchersBase.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
-				.local(false)
-				.snapshotLocation(null)
-				.snapshotSkipValidation(false)
-				.environment(DEFAULT_ENV)
-				.silentMode(null)
-				.snapshotAutoLoad(false)
-				.snapshotAutoUpdateInterval(null));
+				.domain("domain")
+				.apiKey("apiKey")
+				.component("component")
+				.environment(DEFAULT_ENV));
     }
-	
+
 	@AfterAll
 	static void tearDown() {
 		tearDownMockServer();
     }
-	
+
 	@BeforeEach
 	void resetSwitcherContextState() {
 		((QueueDispatcher) mockBackEnd.getDispatcher()).clear();
 
-		Switchers.initializeClient();
+		SwitchersBase.initializeClient();
 	}
 
 	@Test
@@ -59,7 +56,7 @@ class SwitcherBasicCriteriaResponseTest extends MockWebServerHelper {
 		givenResponse(generateCriteriaResponse("true", "Success"));
 
 		//test
-		SwitcherRequest switcher = Switchers.getSwitcher(Switchers.REMOTE_KEY);
+		SwitcherRequest switcher = SwitchersBase.getSwitcher(SwitchersBase.USECASE11);
 		SwitcherResult response = switcher.submit();
 
 		assertTrue(response.isItOn());
@@ -75,7 +72,7 @@ class SwitcherBasicCriteriaResponseTest extends MockWebServerHelper {
 		givenResponse(generateCriteriaResponse("false", "Strategy VALUE_VALIDATION does not agree"));
 
 		//test
-		SwitcherRequest switcher = Switchers.getSwitcher(Switchers.REMOTE_KEY);
+		SwitcherRequest switcher = SwitchersBase.getSwitcher(SwitchersBase.USECASE11);
 		SwitcherResult response = switcher
 				.checkValue("value")
 				.checkNumeric("10")
@@ -87,8 +84,8 @@ class SwitcherBasicCriteriaResponseTest extends MockWebServerHelper {
 
 	@Test
 	void shouldFlushStrategyInputs() {
-		SwitcherBuilder switcherBuilder = Switchers
-				.getSwitcher(Switchers.REMOTE_KEY)
+		SwitcherBuilder switcherBuilder = SwitchersBase
+				.getSwitcher(SwitchersBase.USECASE11)
 				.checkValue("value")
 				.checkNumeric("10");
 
@@ -111,7 +108,7 @@ class SwitcherBasicCriteriaResponseTest extends MockWebServerHelper {
 		givenResponse(generateCriteriaResponse(new MetadataSample("123")));
 
 		//test
-		SwitcherRequest switcher = Switchers.getSwitcher(Switchers.REMOTE_KEY);
+		SwitcherRequest switcher = SwitchersBase.getSwitcher(SwitchersBase.USECASE11);
 		SwitcherResult response = switcher.submit();
 
 		assertEquals("123", response.getMetadata(MetadataSample.class).getTransactionId());
@@ -126,7 +123,7 @@ class SwitcherBasicCriteriaResponseTest extends MockWebServerHelper {
 		givenResponse(generateCriteriaResponse(new MetadataErrorSample("123")));
 
 		//test
-		SwitcherRequest switcher = Switchers.getSwitcher(Switchers.REMOTE_KEY);
+		SwitcherRequest switcher = SwitchersBase.getSwitcher(SwitchersBase.USECASE11);
 		SwitcherResult response = switcher.submit();
 
 		assertNotNull(response.getMetadata(MetadataSample.class));

--- a/src/test/java/com/switcherapi/client/SwitcherBasicTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherBasicTest.java
@@ -1,6 +1,6 @@
 package com.switcherapi.client;
 
-import com.switcherapi.Switchers;
+import com.switcherapi.SwitchersBase;
 import com.switcherapi.client.model.SwitcherRequest;
 import com.switcherapi.fixture.MockWebServerHelper;
 import mockwebserver3.QueueDispatcher;
@@ -22,17 +22,14 @@ class SwitcherBasicTest extends MockWebServerHelper {
 	@BeforeAll
 	static void setup() throws IOException {
 		setupMockServer();
-
-		Switchers.loadProperties(); // Load default properties from resources
-		Switchers.configure(ContextBuilder.builder() // Override default properties
+		
+		SwitchersBase.configure(ContextBuilder.builder(true)
+				.context(SwitchersBase.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
-				.local(false)
-				.snapshotLocation(null)
-				.snapshotSkipValidation(false)
-				.environment(DEFAULT_ENV)
-				.silentMode(null)
-				.snapshotAutoLoad(false)
-				.snapshotAutoUpdateInterval(null));
+				.domain("domain")
+				.apiKey("apiKey")
+				.component("component")
+				.environment(DEFAULT_ENV));
     }
 	
 	@AfterAll
@@ -44,7 +41,7 @@ class SwitcherBasicTest extends MockWebServerHelper {
 	void resetSwitcherContextState() {
 		((QueueDispatcher) mockBackEnd.getDispatcher()).clear();
 
-		Switchers.initializeClient();
+		SwitchersBase.initializeClient();
 	}
 	
 	@Test
@@ -56,7 +53,7 @@ class SwitcherBasicTest extends MockWebServerHelper {
 		givenResponse(generateCriteriaResponse("true", false));
 		
 		//test
-		SwitcherRequest switcher = Switchers.getSwitcher(Switchers.REMOTE_KEY);
+		SwitcherRequest switcher = SwitchersBase.getSwitcher(SwitchersBase.USECASE11);
 		assertTrue(switcher.isItOn());
 	}
 	
@@ -69,7 +66,7 @@ class SwitcherBasicTest extends MockWebServerHelper {
 		givenResponse(generateCriteriaResponse("false", false));
 		
 		//test
-		SwitcherRequest switcher = Switchers.getSwitcher(Switchers.REMOTE_KEY);
+		SwitcherRequest switcher = SwitchersBase.getSwitcher(SwitchersBase.USECASE11);
 		assertFalse(switcher.isItOn());
 	}
 

--- a/src/test/java/com/switcherapi/client/SwitcherConfigNativeTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherConfigNativeTest.java
@@ -56,7 +56,7 @@ class SwitcherConfigNativeTest extends MockWebServerHelper {
 		assertTrue(SwitchersBaseNative.getSwitcher(SwitchersBaseNative.USECASE11).isItOn());
 		assertEquals("switcher-client", context.component);
 		assertEquals("switcher-domain", context.domain);
-		assertEquals("[API_KEY]", context.apikey);
+		assertEquals("apiKey", context.apikey);
 		assertEquals("http://localhost:3000", context.url);
 		assertEquals("fixture1", context.environment);
 	}

--- a/src/test/java/com/switcherapi/client/SwitcherContextBuilderTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherContextBuilderTest.java
@@ -24,9 +24,9 @@ class SwitcherContextBuilderTest {
 		configure(ContextBuilder.builder(true)
 				.context(SwitchersBase.class.getName())
 				.url("http://localhost:3000")
-				.apiKey("API_KEY")
-				.domain("switcher-domain")
-				.component("switcher-client")
+				.apiKey("apiKey")
+				.domain("domain")
+				.component("component")
 				.environment(DEFAULT_ENV)
 				.snapshotLocation(SNAPSHOTS_LOCAL)
 				.local(true));
@@ -44,9 +44,9 @@ class SwitcherContextBuilderTest {
 		configure(ContextBuilder.builder(true)
 				.context(SwitchersBase.class.getName())
 				.url("http://localhost:3000")
-				.apiKey("API_KEY")
-				.domain("switcher-domain")
-				.component("switcher-client")
+				.apiKey("apiKey")
+				.domain("domain")
+				.component("component")
 				.environment(DEFAULT_ENV)
 				.snapshotLocation(null)
 				.local(true));
@@ -61,7 +61,7 @@ class SwitcherContextBuilderTest {
 		//given
 		configure(ContextBuilder.builder(true)
 				.context(SwitchersBase.class.getName())
-				.domain("switcher-domain")
+				.domain("domain")
 				.snapshotLocation(SNAPSHOTS_LOCAL)
 				.local(true));
 

--- a/src/test/java/com/switcherapi/client/SwitcherSilentModeTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSilentModeTest.java
@@ -1,6 +1,6 @@
 package com.switcherapi.client;
 
-import com.switcherapi.Switchers;
+import com.switcherapi.SwitchersBase;
 import com.switcherapi.client.model.SwitcherRequest;
 import com.switcherapi.fixture.CountDownHelper;
 import com.switcherapi.fixture.MockWebServerHelper;
@@ -24,9 +24,6 @@ class SwitcherSilentModeTest extends MockWebServerHelper {
 	@BeforeAll
 	static void setup() throws IOException {
 		setupMockServer();
-        
-        Switchers.loadProperties();
-        Switchers.configure(ContextBuilder.builder().url(String.format("http://localhost:%s", mockBackEnd.getPort())));
     }
 	
 	@AfterAll
@@ -38,25 +35,24 @@ class SwitcherSilentModeTest extends MockWebServerHelper {
 	void resetSwitcherContextState() {
 		((QueueDispatcher) mockBackEnd.getDispatcher()).clear();
 
-		Switchers.configure(ContextBuilder.builder()
-				.local(false)
-				.snapshotLocation(null)
-				.snapshotSkipValidation(false)
-				.environment(DEFAULT_ENV)
-				.silentMode(null)
-				.snapshotAutoLoad(false)
-				.snapshotAutoUpdateInterval(null));
+		SwitchersBase.configure(ContextBuilder.builder(true)
+				.context(SwitchersBase.class.getName())
+				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
+				.domain("domain")
+				.apiKey("apiKey")
+				.component("component")
+				.environment(DEFAULT_ENV));
 	}
 	
 	@Test
 	void shouldReturnTrue_silentMode() {
 		//given
-		Switchers.configure(ContextBuilder.builder()
+		SwitchersBase.configure(ContextBuilder.builder()
 				.snapshotLocation(SNAPSHOTS_LOCAL)
 				.environment("fixture1")
 				.silentMode("5s"));
-		
-		Switchers.initializeClient();
+
+		SwitchersBase.initializeClient();
 		
 		//auth
 		givenResponse(generateMockAuth(10));
@@ -65,7 +61,7 @@ class SwitcherSilentModeTest extends MockWebServerHelper {
 		givenResponse(generateCriteriaResponse("true", false));
 		
 		//test
-		SwitcherRequest switcher = Switchers.getSwitcher(Switchers.USECASE11);
+		SwitcherRequest switcher = SwitchersBase.getSwitcher(SwitchersBase.USECASE11);
 		assertTrue(switcher.isItOn());
 
 		CountDownHelper.wait(2);

--- a/src/test/java/com/switcherapi/client/SwitcherSnapshotAutoUpdate2Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSnapshotAutoUpdate2Test.java
@@ -49,7 +49,7 @@ class SwitcherSnapshotAutoUpdate2Test extends MockWebServerHelper {
 		Switchers.configure(ContextBuilder.builder(true)
 				.context(Switchers.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
-				.apiKey("[API_KEY]")
+				.apiKey("apiKey")
 				.environment("generated_mock_default_6")
 				.local(true)
 				.snapshotAutoLoad(true)
@@ -65,8 +65,8 @@ class SwitcherSnapshotAutoUpdate2Test extends MockWebServerHelper {
 		givenResponse(generateSnapshotResponse("default.json", SNAPSHOTS_LOCAL)); //graphql
 
 		//test
-		CountDownHelper.wait(2);
-		assertEquals(2, Switchers.getSnapshotVersion());
+		assertEquals(2,
+				CountDownHelper.waitUntil(10, 2L, Switchers::getSnapshotVersion));
 	}
 
 }

--- a/src/test/java/com/switcherapi/client/SwitcherSnapshotAutoUpdateTest.java
+++ b/src/test/java/com/switcherapi/client/SwitcherSnapshotAutoUpdateTest.java
@@ -87,7 +87,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 		Switchers.configure(ContextBuilder.builder(true)
 				.context(Switchers.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
-				.apiKey("[API_KEY]")
+				.apiKey("apiKey")
 				.snapshotLocation(SNAPSHOTS_LOCAL)
 				.environment("generated_mock_default_2")
 				.local(true)
@@ -98,8 +98,8 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 		assertEquals(1, Switchers.getSnapshotVersion());
 
 		//test
-		CountDownHelper.wait(2);
-		assertEquals(2, Switchers.getSnapshotVersion());
+		assertEquals(2,
+				CountDownHelper.waitUntil(10, 2L, Switchers::getSnapshotVersion));
 	}
 
 	@Test
@@ -112,7 +112,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 		Switchers.configure(ContextBuilder.builder(true)
 				.context(Switchers.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
-				.apiKey("[API_KEY]")
+				.apiKey("apiKey")
 				.domain("Test")
 				.component("switcher-test")
 				.snapshotLocation(SNAPSHOTS_LOCAL)
@@ -125,8 +125,8 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 		assertEquals(1, Switchers.getSnapshotVersion());
 
 		//test
-		CountDownHelper.wait(2);
-		assertEquals(2, Switchers.getSnapshotVersion());
+		assertEquals(2,
+				CountDownHelper.waitUntil(10, 2L, Switchers::getSnapshotVersion));
 	}
 
 	@Test
@@ -139,7 +139,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 		Switchers.configure(ContextBuilder.builder(true)
 				.context(Switchers.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
-				.apiKey("[API_KEY]")
+				.apiKey("apiKey")
 				.snapshotLocation(SNAPSHOTS_LOCAL)
 				.environment("generated_mock_default_4")
 				.local(true)
@@ -150,8 +150,8 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 		assertEquals(1, Switchers.getSnapshotVersion());
 
 		//test - still the same version
-		CountDownHelper.wait(1);
-		assertEquals(1, Switchers.getSnapshotVersion());
+		assertEquals(1,
+				CountDownHelper.waitUntil(10, 1L, Switchers::getSnapshotVersion));
 	}
 
 	@Test
@@ -167,7 +167,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 		Switchers.configure(ContextBuilder.builder(true)
 				.context(Switchers.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
-				.apiKey("[API_KEY]")
+				.apiKey("apiKey")
 				.environment("generated_mock_default_5")
 				.local(true)
 				.snapshotLocation("")
@@ -178,9 +178,8 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 		assertEquals(1, Switchers.getSnapshotVersion());
 
 		//test
-		CountDownHelper.wait(2);
-		assertEquals(2, Switchers.getSnapshotVersion());
-		assertTrue(Files.notExists(Paths.get("/generated_mock_default_5.json")));
+		assertEquals(2,
+				CountDownHelper.waitUntil(10, 2L, Switchers::getSnapshotVersion));
 	}
 
 	@Test
@@ -198,7 +197,7 @@ class SwitcherSnapshotAutoUpdateTest extends MockWebServerHelper {
 		Switchers.configure(ContextBuilder.builder(true)
 				.context(Switchers.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
-				.apiKey("[API_KEY]")
+				.apiKey("apiKey")
 				.environment("generated_mock_default_6")
 				.local(true)
 				.snapshotAutoLoad(true)

--- a/src/test/java/com/switcherapi/client/SwitcherThrottle1Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherThrottle1Test.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
 import static com.switcherapi.client.remote.Constants.DEFAULT_ENV;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SwitcherThrottle1Test extends MockWebServerHelper {
@@ -23,9 +23,9 @@ class SwitcherThrottle1Test extends MockWebServerHelper {
 		SwitchersBase.configure(ContextBuilder.builder(true)
 				.context(SwitchersBase.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
-				.apiKey("TEST_API_KEY")
-				.domain("TEST_DOMAIN")
-				.component("TEST_COMPONENT")
+				.apiKey("apiKey")
+				.domain("domain")
+				.component("component")
 				.environment(DEFAULT_ENV));
 
 		SwitchersBase.initializeClient();
@@ -58,8 +58,8 @@ class SwitcherThrottle1Test extends MockWebServerHelper {
 			assertTrue(switcher.isItOn());
 		}
 
-		CountDownHelper.wait(1);
-		assertFalse(switcher.isItOn());
+		assertEquals(Boolean.FALSE,
+				CountDownHelper.waitUntil(10, false, switcher::isItOn));
 	}
 
 }

--- a/src/test/java/com/switcherapi/client/SwitcherThrottle2Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherThrottle2Test.java
@@ -22,9 +22,9 @@ class SwitcherThrottle2Test extends MockWebServerHelper {
 		SwitchersBase.configure(ContextBuilder.builder(true)
 				.context(SwitchersBase.class.getName())
 				.url(String.format("http://localhost:%s", mockBackEnd.getPort()))
-				.apiKey("TEST_API_KEY")
-				.domain("TEST_DOMAIN")
-				.component("TEST_COMPONENT")
+				.apiKey("apiKey")
+				.domain("domain")
+				.component("component")
 				.environment(DEFAULT_ENV));
 
 		SwitchersBase.initializeClient();

--- a/src/test/java/com/switcherapi/client/utils/SnapshotTest.java
+++ b/src/test/java/com/switcherapi/client/utils/SnapshotTest.java
@@ -6,6 +6,7 @@ import com.switcherapi.client.model.criteria.Snapshot;
 import com.switcherapi.client.service.WorkerName;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.switcherapi.fixture.CountDownHelper;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,7 +67,11 @@ abstract class SnapshotTest {
 	}
 
 	protected void assertWorker(boolean exists) {
-		assertEquals(exists, Thread.getAllStackTraces().keySet().stream()
-				.anyMatch(t -> t.getName().equals(WorkerName.SNAPSHOT_WATCH_WORKER.toString())));
+		assertWorker(exists, 5);
+	}
+
+	protected void assertWorker(boolean exists, int timeout) {
+		assertEquals(exists, CountDownHelper.waitUntil(timeout, exists, () -> Thread.getAllStackTraces().keySet().stream()
+				.anyMatch(t -> t.getName().equals(WorkerName.SNAPSHOT_WATCH_WORKER.toString()))));
 	}
 }

--- a/src/test/java/com/switcherapi/client/utils/SnapshotWatcherContextTest.java
+++ b/src/test/java/com/switcherapi/client/utils/SnapshotWatcherContextTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/src/test/java/com/switcherapi/client/utils/SnapshotWatcherContextTest.java
+++ b/src/test/java/com/switcherapi/client/utils/SnapshotWatcherContextTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.*;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SnapshotWatcherContextTest extends SnapshotTest {
@@ -60,10 +61,9 @@ class SnapshotWatcherContextTest extends SnapshotTest {
 		//when we change the fixture
 		this.changeFixture();
 
-		CountDownHelper.wait(2);
-
 		//snapshot file updated - triggered domain reload
-		assertFalse(switcher.isItOn());
+		assertNotEquals(Boolean.TRUE,
+				CountDownHelper.waitUntil(10, false, switcher::isItOn));
 	}
 
 }

--- a/src/test/java/com/switcherapi/client/utils/SnapshotWatcherErrorTest.java
+++ b/src/test/java/com/switcherapi/client/utils/SnapshotWatcherErrorTest.java
@@ -16,9 +16,9 @@ class SnapshotWatcherErrorTest {
 		SwitchersBase.configure(ContextBuilder.builder(true)
 			.context(SwitchersBase.class.getName())
 			.url("https://api.switcherapi.com")
-			.apiKey("[API_KEY]")
-			.domain("Test")
-			.component("switcher-test")
+			.apiKey("apiKey")
+			.domain("domain")
+			.component("component")
 			.local(false));
 
 		SwitchersBase.initializeClient();

--- a/src/test/java/com/switcherapi/client/utils/SnapshotWatcherTest.java
+++ b/src/test/java/com/switcherapi/client/utils/SnapshotWatcherTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SnapshotWatcherTest extends SnapshotTest {
@@ -53,10 +53,9 @@ class SnapshotWatcherTest extends SnapshotTest {
 		SwitchersBase.stopWatchingSnapshot();
 		this.changeFixture();
 
-		CountDownHelper.wait(2);
-
 		//snapshot file updated - does not change as the watcher has been terminated
-		assertTrue(switcher.isItOn());
+		assertEquals(Boolean.TRUE,
+				CountDownHelper.waitUntil(10, true, switcher::isItOn));
 	}
 	
 	@Test
@@ -67,13 +66,12 @@ class SnapshotWatcherTest extends SnapshotTest {
 		assertTrue(switcher.isItOn());
 
 		CountDownHelper.wait(1);
-		
+
 		this.changeFixture();
 
-		CountDownHelper.wait(2);
-
 		//snapshot file updated - triggered domain reload
-		assertFalse(switcher.isItOn());
+		assertEquals(Boolean.FALSE,
+				CountDownHelper.waitUntil(10, false, switcher::isItOn));
 	}
 
 }

--- a/src/test/java/com/switcherapi/client/utils/SnapshotWatcherWorkerTest.java
+++ b/src/test/java/com/switcherapi/client/utils/SnapshotWatcherWorkerTest.java
@@ -2,7 +2,6 @@ package com.switcherapi.client.utils;
 
 import com.switcherapi.SwitchersBase;
 import com.switcherapi.client.ContextBuilder;
-import com.switcherapi.fixture.CountDownHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -27,9 +26,8 @@ class SnapshotWatcherWorkerTest extends SnapshotTest {
 		assertWorker(true);
 
 		SwitchersBase.stopWatchingSnapshot();
-		CountDownHelper.wait(2);
 
-		assertWorker(false);
+		assertWorker(false, 10);
 	}
 
 }

--- a/src/test/java/com/switcherapi/fixture/CountDownHelper.java
+++ b/src/test/java/com/switcherapi/fixture/CountDownHelper.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 public class CountDownHelper {
 
@@ -21,5 +22,17 @@ public class CountDownHelper {
         } catch (InterruptedException e) {
             logger.error(e.getMessage(), e);
         }
+    }
+
+    public static <T> T waitUntil(int timeout, T expected, Supplier<T> condition) {
+        long startTime = System.currentTimeMillis();
+        while (System.currentTimeMillis() - startTime < timeout * 1000L) {
+            T result = condition.get();
+            if (expected.equals(result)) {
+                return result;
+            }
+            wait(1);
+        }
+        return null;
     }
 }

--- a/src/test/resources/switcherapi-native.properties
+++ b/src/test/resources/switcherapi-native.properties
@@ -1,5 +1,5 @@
 switcher.url=http://localhost:3000
-switcher.apikey=[API_KEY]
+switcher.apikey=apiKey
 switcher.component=switcher-client
 switcher.environment=fixture1
 switcher.domain=switcher-domain

--- a/src/test/resources/switcherapi-optionals.properties
+++ b/src/test/resources/switcherapi-optionals.properties
@@ -1,6 +1,6 @@
 switcher.context=com.switcherapi.SwitchersBase
 switcher.url=http://localhost:3000
-switcher.apikey=[API_KEY]
+switcher.apikey=apiKey
 switcher.component=switcher-client
 switcher.environment=test
 switcher.domain=switcher-domain

--- a/src/test/resources/switcherapi.properties
+++ b/src/test/resources/switcherapi.properties
@@ -1,6 +1,6 @@
 switcher.context=com.switcherapi.Switchers
 switcher.url=http://localhost:3000
-switcher.apikey=[API_KEY]
+switcher.apikey=apiKey
 switcher.component=switcher-client
 switcher.environment=test
 switcher.domain=switcher-domain


### PR DESCRIPTION
This pull request primarily updates the documentation and test code to standardize the use of placeholder values and to migrate tests from the `Switchers` class to the new `SwitchersBase` class. It also improves test reliability by using a utility function to wait for snapshot updates instead of fixed delays.

Key changes include:

**Documentation and Placeholder Updates:**

* Updated the `README.md` and code comments to use consistent placeholder values (`[API_KEY]`, `[DOMAIN_NAME]`, `[COMPONENT_NAME]`) instead of hardcoded or example strings for configuration properties and code samples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L126-R128) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L191-R194) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L340-R342) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L385-R390) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L421-R424) [[6]](diffhunk://#diff-58fea277cde9b83cbb7929cce8f315b3577b69c0b7f98a82273c85e8a77d616eL69-R71)

**Test Refactoring to SwitchersBase:**

* Migrated test imports and usages from the `Switchers` class to `SwitchersBase` in several test files, updating configuration and switcher retrieval accordingly. [[1]](diffhunk://#diff-1637d741bf06576210932de03cfd3051e896beafa7cdeb07bb977f1f84c1c3beL3-R3) [[2]](diffhunk://#diff-1637d741bf06576210932de03cfd3051e896beafa7cdeb07bb977f1f84c1c3beL29-R35) [[3]](diffhunk://#diff-1637d741bf06576210932de03cfd3051e896beafa7cdeb07bb977f1f84c1c3beL50-R47) [[4]](diffhunk://#diff-1637d741bf06576210932de03cfd3051e896beafa7cdeb07bb977f1f84c1c3beL62-R59) [[5]](diffhunk://#diff-1637d741bf06576210932de03cfd3051e896beafa7cdeb07bb977f1f84c1c3beL78-R75) [[6]](diffhunk://#diff-1637d741bf06576210932de03cfd3051e896beafa7cdeb07bb977f1f84c1c3beL90-R88) [[7]](diffhunk://#diff-1637d741bf06576210932de03cfd3051e896beafa7cdeb07bb977f1f84c1c3beL114-R111) [[8]](diffhunk://#diff-1637d741bf06576210932de03cfd3051e896beafa7cdeb07bb977f1f84c1c3beL129-R126) [[9]](diffhunk://#diff-3d8fc35838bbce9ed2e039cdb404eeeee57d575f3f7c0b2416a4a4e1baafc1feL3-R3) [[10]](diffhunk://#diff-3d8fc35838bbce9ed2e039cdb404eeeee57d575f3f7c0b2416a4a4e1baafc1feL26-R32) [[11]](diffhunk://#diff-3d8fc35838bbce9ed2e039cdb404eeeee57d575f3f7c0b2416a4a4e1baafc1feL47-R44) [[12]](diffhunk://#diff-3d8fc35838bbce9ed2e039cdb404eeeee57d575f3f7c0b2416a4a4e1baafc1feL59-R56) [[13]](diffhunk://#diff-3d8fc35838bbce9ed2e039cdb404eeeee57d575f3f7c0b2416a4a4e1baafc1feL72-R69) [[14]](diffhunk://#diff-68675ebc3cb8a0523258700aaa4aa2983b9043bd0fc955a51bb50ac8e5bd0e1aL3-R3) [[15]](diffhunk://#diff-68675ebc3cb8a0523258700aaa4aa2983b9043bd0fc955a51bb50ac8e5bd0e1aL27-L29) [[16]](diffhunk://#diff-68675ebc3cb8a0523258700aaa4aa2983b9043bd0fc955a51bb50ac8e5bd0e1aL41-R55) [[17]](diffhunk://#diff-68675ebc3cb8a0523258700aaa4aa2983b9043bd0fc955a51bb50ac8e5bd0e1aL68-R64)

**Test Configuration and Consistency:**

* Standardized test context configuration to use the same placeholder values and consistent setup across tests, including updating expected values in assertions. [[1]](diffhunk://#diff-6fc7b32e3a7874348da82f2337939679aadf0dd8277fad4c46b1e5d52064d3cdL59-R59) [[2]](diffhunk://#diff-bb42bc1f7b15ae7c040873c7b2db438ececce1deb5e117b6c7c9fe20c1e3a889L27-R29) [[3]](diffhunk://#diff-bb42bc1f7b15ae7c040873c7b2db438ececce1deb5e117b6c7c9fe20c1e3a889L47-R49) [[4]](diffhunk://#diff-bb42bc1f7b15ae7c040873c7b2db438ececce1deb5e117b6c7c9fe20c1e3a889L64-R64)

**Test Reliability Improvements:**

* Replaced fixed `wait` calls with a utility function (`CountDownHelper.waitUntil`) to more reliably wait for snapshot version updates in snapshot auto-update tests. [[1]](diffhunk://#diff-2fedb5772aa51d83da54d11ca4eab750918d3b5c36adc46d5a8cdd9db5d3b544L52-R52) [[2]](diffhunk://#diff-2fedb5772aa51d83da54d11ca4eab750918d3b5c36adc46d5a8cdd9db5d3b544L68-R69) [[3]](diffhunk://#diff-515cd3e749786473ad6acca63180ceaa49648e7b6b1f44931b5adbf117bebbb8L90-R90) [[4]](diffhunk://#diff-515cd3e749786473ad6acca63180ceaa49648e7b6b1f44931b5adbf117bebbb8L101-R102) [[5]](diffhunk://#diff-515cd3e749786473ad6acca63180ceaa49648e7b6b1f44931b5adbf117bebbb8L115-R115)