### PR TITLE
fix: registerSwitcherKeys to load contextBase from location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 		<slf4j-api.version>2.0.18</slf4j-api.version>
 
 		<!-- test -->
-		<okhttp.version>5.3.2</okhttp.version>
+		<okhttp.version>5.4.0</okhttp.version>
 		<junit-jupiter.version>6.1.0</junit-jupiter.version>
 		<junit-pioneer.version>2.3.0</junit-pioneer.version>
 		<junit-platform-launcher.version>6.1.0</junit-platform-launcher.version>
@@ -67,11 +67,11 @@
 		<maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
 		<maven-source-plugin.version>3.4.0</maven-source-plugin.version>
 		<maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
-		<maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+		<maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
 		<maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
-		<sonar-maven-plugin.version>5.6.0.6792</sonar-maven-plugin.version>
-		<jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
-		<central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
+		<sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
+		<jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
+		<central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
 
 		<!-- Sonar -->
 		<sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>

--- a/src/main/java/com/switcherapi/client/SwitcherContextBase.java
+++ b/src/main/java/com/switcherapi/client/SwitcherContextBase.java
@@ -229,11 +229,13 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 	 * Register Switcher Keys based on context properties
 	 */
 	private static void registerSwitcherKeys() {
-		if (Objects.nonNull(contextBase)) {
+		final String contextLocation = contextStr(ContextKey.CONTEXT_LOCATION);
+
+		if (Objects.nonNull(contextBase) && contextBase.getClass().getName().equals(contextLocation)) {
 			registerSwitcherKey(contextBase.getClass().getFields());
 		} else {
 			try {
-				final Class<?> clazz = Class.forName(contextStr(ContextKey.CONTEXT_LOCATION));
+				final Class<?> clazz = Class.forName(contextLocation);
 				registerSwitcherKey(clazz.getFields());
 			} catch(ClassNotFoundException e){
 				throw new SwitcherContextException(e.getMessage());

--- a/src/main/java/com/switcherapi/client/SwitcherContextBase.java
+++ b/src/main/java/com/switcherapi/client/SwitcherContextBase.java
@@ -249,6 +249,8 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 	private static void registerSwitcherKey(Field[] fields) {
 		Set<String> switcherKeys = new HashSet<>();
 
+		SwitcherUtils.debug(logger, "Registering Switcher Keys from context: {}", contextStr(ContextKey.CONTEXT_LOCATION));
+		SwitcherUtils.debug(logger, "Found {} fields in context class", fields.length);
 		for (Field field : fields) {
 			if (field.isAnnotationPresent(SwitcherKey.class)) {
 				try {

--- a/src/main/java/com/switcherapi/client/SwitcherContextBase.java
+++ b/src/main/java/com/switcherapi/client/SwitcherContextBase.java
@@ -254,7 +254,9 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 		for (Field field : fields) {
 			if (field.isAnnotationPresent(SwitcherKey.class)) {
 				try {
-					switcherKeys.add(field.get(null).toString());
+					final String keyFound = field.get(null).toString();
+					SwitcherUtils.debug(logger, "Found Switcher Key: {} in field: {}", keyFound, field.getName());
+					switcherKeys.add(keyFound);
 				} catch (Exception e) {
 					throw new SwitcherContextException(
 							String.format("Error retrieving Switcher Key value from field %s", field.getName()));

--- a/src/test/java/com/switcherapi/client/SwitcherFail3Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherFail3Test.java
@@ -16,7 +16,7 @@ class SwitcherFail3Test {
 	@Test
 	void shouldNotRegisterSwitcher_nullKey() {
 		//given
-		TestCaseNull.configure(ContextBuilder.builder()
+		TestCaseNull.configure(ContextBuilder.builder(true)
 				.context(TestCaseNull.class.getName())
 				.snapshotLocation(SNAPSHOTS_LOCAL)
 				.local(true));
@@ -30,7 +30,7 @@ class SwitcherFail3Test {
 	@Test
 	void shouldNotRegisterSwitcher_emptyKey() {
 		//given
-		TestCaseEmpty.configure(ContextBuilder.builder()
+		TestCaseEmpty.configure(ContextBuilder.builder(true)
 				.context(TestCaseEmpty.class.getName())
 				.snapshotLocation(SNAPSHOTS_LOCAL)
 				.local(true));

--- a/src/test/java/com/switcherapi/client/SwitcherFail3Test.java
+++ b/src/test/java/com/switcherapi/client/SwitcherFail3Test.java
@@ -16,7 +16,7 @@ class SwitcherFail3Test {
 	@Test
 	void shouldNotRegisterSwitcher_nullKey() {
 		//given
-		TestCaseNull.configure(ContextBuilder.builder(true)
+		TestCaseNull.configure(ContextBuilder.builder()
 				.context(TestCaseNull.class.getName())
 				.snapshotLocation(SNAPSHOTS_LOCAL)
 				.local(true));
@@ -30,7 +30,7 @@ class SwitcherFail3Test {
 	@Test
 	void shouldNotRegisterSwitcher_emptyKey() {
 		//given
-		TestCaseEmpty.configure(ContextBuilder.builder(true)
+		TestCaseEmpty.configure(ContextBuilder.builder()
 				.context(TestCaseEmpty.class.getName())
 				.snapshotLocation(SNAPSHOTS_LOCAL)
 				.local(true));


### PR DESCRIPTION
This pull request updates several dependencies in `pom.xml` and improves the debug logging and validation logic for registering Switcher Keys in `SwitcherContextBase.java`. The most important changes are:

Dependency updates:

* Updated `okhttp` to version 5.4.0, `maven-surefire-plugin` to 3.5.6, `sonar-maven-plugin` to 5.7.0.6970, `jacoco-maven-plugin` to 0.8.15, and `central-publishing-maven-plugin` to 0.11.0 for improved compatibility and bug fixes. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L61-R61) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L70-R74)

Switcher Key registration improvements:

* Enhanced the logic in `registerSwitcherKeys()` to verify that the current context class matches the expected context location before registering keys, ensuring more accurate context handling.
* Added detailed debug logging to `registerSwitcherKey()` to trace context location, number of fields found, and each Switcher Key registered, improving observability and troubleshooting.