### PR TITLE
fix: registerSwitcherKeys to load contextBase from location

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Get PR details
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = await github.rest.pulls.get({

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 		<slf4j-api.version>2.0.18</slf4j-api.version>
 
 		<!-- test -->
-		<okhttp.version>5.3.2</okhttp.version>
+		<okhttp.version>5.4.0</okhttp.version>
 		<junit-jupiter.version>5.14.4</junit-jupiter.version>
 		<junit-pioneer.version>1.9.1</junit-pioneer.version>
 		<junit-platform-launcher.version>1.14.4</junit-platform-launcher.version>
@@ -73,11 +73,11 @@
 		<maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
 		<maven-source-plugin.version>3.4.0</maven-source-plugin.version>
 		<maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
-		<maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+		<maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
 		<maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
-		<sonar-maven-plugin.version>5.6.0.6792</sonar-maven-plugin.version>
-		<jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
-		<central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
+		<sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
+		<jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
+		<central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
 
 		<!-- Sonar -->
 		<sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>

--- a/src/main/java/com/switcherapi/client/SwitcherContextBase.java
+++ b/src/main/java/com/switcherapi/client/SwitcherContextBase.java
@@ -230,11 +230,13 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 	 * Register Switcher Keys based on context properties
 	 */
 	private static void registerSwitcherKeys() {
-		if (Objects.nonNull(contextBase)) {
+		final String contextLocation = contextStr(ContextKey.CONTEXT_LOCATION);
+
+		if (Objects.nonNull(contextBase) && contextBase.getClass().getName().equals(contextLocation)) {
 			registerSwitcherKey(contextBase.getClass().getFields());
 		} else {
 			try {
-				final Class<?> clazz = Class.forName(contextStr(ContextKey.CONTEXT_LOCATION));
+				final Class<?> clazz = Class.forName(contextLocation);
 				registerSwitcherKey(clazz.getFields());
 			} catch(ClassNotFoundException e){
 				throw new SwitcherContextException(e.getMessage());
@@ -250,10 +252,14 @@ public abstract class SwitcherContextBase extends SwitcherConfig {
 	private static void registerSwitcherKey(Field[] fields) {
 		Set<String> switcherKeys = new HashSet<>();
 
+		SwitcherUtils.debug(logger, "Registering Switcher Keys from context: {}", contextStr(ContextKey.CONTEXT_LOCATION));
+		SwitcherUtils.debug(logger, "Found {} fields in context class", fields.length);
 		for (Field field : fields) {
 			if (field.isAnnotationPresent(SwitcherKey.class)) {
 				try {
-					switcherKeys.add(field.get(null).toString());
+					final String keyFound = field.get(null).toString();
+					SwitcherUtils.debug(logger, "Found Switcher Key: {} in field: {}", keyFound, field.getName());
+					switcherKeys.add(keyFound);
 				} catch (Exception e) {
 					throw new SwitcherContextException(
 							String.format("Error retrieving Switcher Key value from field %s", field.getName()));


### PR DESCRIPTION
This pull request updates dependencies and improves debugging for context key registration. The most important changes are grouped below.

**Dependency Updates:**

* Updated `okhttp` to version 5.4.0 in `pom.xml` for improved stability and features.
* Upgraded several Maven plugins in `pom.xml`, including `maven-surefire-plugin`, `sonar-maven-plugin`, `jacoco-maven-plugin`, and `central-publishing-maven-plugin` to their latest versions for better build and analysis support.
* Updated the GitHub Action `actions/github-script` from v7 to v9 in `.github/workflows/sonar.yml` to use newer features and fixes.

**Debugging Improvements:**

* Enhanced logging in `registerSwitcherKey` (in `SwitcherContextBase.java`) to provide more details during Switcher Key registration, including context class and field information.

**Context Registration Logic:**

* Improved context key registration logic in `SwitcherContextBase.java` to ensure keys are only registered if the context class matches the expected location, increasing reliability.