### PR TITLE
fix: replaced Date with java.time API (#397)

### DIFF
--- a/src/main/java/com/switcherapi/client/service/remote/ClientRemoteService.java
+++ b/src/main/java/com/switcherapi/client/service/remote/ClientRemoteService.java
@@ -17,7 +17,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -147,7 +147,7 @@ public class ClientRemoteService implements ClientRemote {
 			final AuthResponse response = new AuthResponse();
 			
 			response.setToken(ContextKey.SILENT_MODE.getParam());
-			response.setExp(SwitcherUtils.addTimeDuration(addValue, new Date()).getTime()/1000);
+			response.setExp(SwitcherUtils.addTimeDuration(addValue, Instant.now()).getEpochSecond());
 			this.authResponse = response;
 		}
 	}

--- a/src/main/java/com/switcherapi/client/service/validators/DateValidator.java
+++ b/src/main/java/com/switcherapi/client/service/validators/DateValidator.java
@@ -7,14 +7,15 @@ import com.switcherapi.client.model.Entry;
 import com.switcherapi.client.model.EntryOperation;
 import com.switcherapi.client.model.StrategyValidator;
 import com.switcherapi.client.model.criteria.StrategyConfig;
-import org.apache.commons.lang3.time.DateUtils;
 
-import java.text.ParseException;
-import java.util.Date;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 public class DateValidator extends DateTimeValidator {
 
 	public static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT);
 
 	@Override
 	public StrategyValidator getType() {
@@ -27,34 +28,34 @@ public class DateValidator extends DateTimeValidator {
 
 		try {
 			return selectDateOperationCase(strategyConfig, switcherInput);
-		} catch (ParseException e) {
+		} catch (DateTimeParseException e) {
 			throw new SwitcherInvalidTimeFormat(strategyConfig.getStrategy(), e);
 		}
 	}
 
-	private boolean selectDateOperationCase(final StrategyConfig strategyConfig, final Entry switcherInput) throws ParseException {
-		Date stgDate;
-		Date stgDate2;
-		Date inputDate;
+	private boolean selectDateOperationCase(final StrategyConfig strategyConfig, final Entry switcherInput) {
+		LocalDateTime stgDate;
+		LocalDateTime stgDate2;
+		LocalDateTime inputDate;
 
 		switch (strategyConfig.getEntryOperation()) {
 		case LOWER:
-			stgDate = DateUtils.parseDate(getFullDate(strategyConfig.getValues()[0]), DATE_FORMAT);
-			inputDate = DateUtils.parseDate(getFullDate(switcherInput.getInput()), DATE_FORMAT);
+			stgDate = LocalDateTime.parse(getFullDate(strategyConfig.getValues()[0]), FORMATTER);
+			inputDate = LocalDateTime.parse(getFullDate(switcherInput.getInput()), FORMATTER);
 
-			return inputDate.before(stgDate);
+			return inputDate.isBefore(stgDate);
 		case GREATER:
-			stgDate = DateUtils.parseDate(getFullDate(strategyConfig.getValues()[0]), DATE_FORMAT);
-			inputDate = DateUtils.parseDate(getFullDate(switcherInput.getInput()), DATE_FORMAT);
+			stgDate = LocalDateTime.parse(getFullDate(strategyConfig.getValues()[0]), FORMATTER);
+			inputDate = LocalDateTime.parse(getFullDate(switcherInput.getInput()), FORMATTER);
 
-			return inputDate.after(stgDate);
+			return inputDate.isAfter(stgDate);
 		case BETWEEN:
 			if (strategyConfig.getValues().length == 2) {
-				stgDate = DateUtils.parseDate(getFullDate(strategyConfig.getValues()[0]), DATE_FORMAT);
-				stgDate2 = DateUtils.parseDate(getFullDate(strategyConfig.getValues()[1]), DATE_FORMAT);
-				inputDate = DateUtils.parseDate(getFullDate(switcherInput.getInput()), DATE_FORMAT);
+				stgDate = LocalDateTime.parse(getFullDate(strategyConfig.getValues()[0]), FORMATTER);
+				stgDate2 = LocalDateTime.parse(getFullDate(strategyConfig.getValues()[1]), FORMATTER);
+				inputDate = LocalDateTime.parse(getFullDate(switcherInput.getInput()), FORMATTER);
 
-				return inputDate.after(stgDate) && inputDate.before(stgDate2);
+				return inputDate.isAfter(stgDate) && inputDate.isBefore(stgDate2);
 			}
 
 			throw new SwitcherInvalidOperationInputException(EntryOperation.BETWEEN.name());

--- a/src/main/java/com/switcherapi/client/service/validators/TimeValidator.java
+++ b/src/main/java/com/switcherapi/client/service/validators/TimeValidator.java
@@ -7,15 +7,17 @@ import com.switcherapi.client.model.Entry;
 import com.switcherapi.client.model.EntryOperation;
 import com.switcherapi.client.model.StrategyValidator;
 import com.switcherapi.client.model.criteria.StrategyConfig;
-import org.apache.commons.lang3.time.DateUtils;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 public class TimeValidator extends DateTimeValidator {
 
 	public static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT);
 
 	@Override
 	public StrategyValidator getType() {
@@ -27,40 +29,37 @@ public class TimeValidator extends DateTimeValidator {
 			SwitcherInvalidTimeFormat, SwitcherInvalidOperationInputException {
 
 		try {
-			final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
-			final String today = format.format(new Date());
+			final String today = LocalDate.now(ZoneId.systemDefault()).toString();
 			return selectTimeOperationCase(strategyConfig, switcherInput, today);
-		} catch (ParseException e) {
+		} catch (DateTimeParseException e) {
 			throw new SwitcherInvalidTimeFormat(strategyConfig.getStrategy(), e);
 		}
 
 	}
 
-	private boolean selectTimeOperationCase(final StrategyConfig strategyConfig, final Entry switcherInput, final String today)
-			throws ParseException {
-		Date stgDate;
-		Date stgDate2;
-		Date inputDate;
+	private boolean selectTimeOperationCase(final StrategyConfig strategyConfig, final Entry switcherInput, final String today) {
+		LocalDateTime stgDate;
+		LocalDateTime stgDate2;
+		LocalDateTime inputDate;
 
 		switch (strategyConfig.getEntryOperation()) {
 		case LOWER:
-			stgDate = DateUtils.parseDate(getFullTime(today, strategyConfig.getValues()[0]), DATE_FORMAT);
-			inputDate = DateUtils.parseDate(getFullTime(today, switcherInput.getInput()), DATE_FORMAT);
+			stgDate = LocalDateTime.parse(getFullTime(today, strategyConfig.getValues()[0]), FORMATTER);
+			inputDate = LocalDateTime.parse(getFullTime(today, switcherInput.getInput()), FORMATTER);
 
-			return inputDate.before(stgDate);
+			return inputDate.isBefore(stgDate);
 		case GREATER:
-			stgDate = DateUtils.parseDate(getFullTime(today, strategyConfig.getValues()[0]), DATE_FORMAT);
-			inputDate = DateUtils.parseDate(getFullTime(today, switcherInput.getInput()), DATE_FORMAT);
+			stgDate = LocalDateTime.parse(getFullTime(today, strategyConfig.getValues()[0]), FORMATTER);
+			inputDate = LocalDateTime.parse(getFullTime(today, switcherInput.getInput()), FORMATTER);
 
-			return inputDate.after(stgDate);
+			return inputDate.isAfter(stgDate);
 		case BETWEEN:
 			if (strategyConfig.getValues().length == 2) {
-				stgDate = DateUtils.parseDate(getFullTime(today, strategyConfig.getValues()[0]), DATE_FORMAT);
-				stgDate2 = DateUtils.parseDate(getFullTime(today, strategyConfig.getValues()[1]), DATE_FORMAT);
-				inputDate = DateUtils.parseDate(getFullTime(today, switcherInput.getInput()),
-						DATE_FORMAT);
+				stgDate = LocalDateTime.parse(getFullTime(today, strategyConfig.getValues()[0]), FORMATTER);
+				stgDate2 = LocalDateTime.parse(getFullTime(today, strategyConfig.getValues()[1]), FORMATTER);
+				inputDate = LocalDateTime.parse(getFullTime(today, switcherInput.getInput()), FORMATTER);
 
-				return inputDate.after(stgDate) && inputDate.before(stgDate2);
+				return inputDate.isAfter(stgDate) && inputDate.isBefore(stgDate2);
 			}
 
 			throw new SwitcherInvalidOperationInputException(EntryOperation.BETWEEN.name());

--- a/src/main/java/com/switcherapi/client/utils/SwitcherUtils.java
+++ b/src/main/java/com/switcherapi/client/utils/SwitcherUtils.java
@@ -7,9 +7,10 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.time.DateUtils;
 import org.slf4j.Logger;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
@@ -28,17 +29,17 @@ public class SwitcherUtils {
 
 	private SwitcherUtils() {}
 	
-	public static Date addTimeDuration(final String addValue, final Date date) 
+	public static Instant addTimeDuration(final String addValue, final Instant instant)
 			throws SwitcherInvalidDateTimeArgumentException {
 		switch (addValue.charAt(addValue.length() - 1)) {
 			case 's':
-				return DateUtils.addSeconds(date, Integer.parseInt(addValue.replace(DURATION_UNIT[0], StringUtils.EMPTY)));
+				return instant.plus(Integer.parseInt(addValue.replace(DURATION_UNIT[0], StringUtils.EMPTY)), ChronoUnit.SECONDS);
 			case 'm':
-				return DateUtils.addMinutes(date, Integer.parseInt(addValue.replace(DURATION_UNIT[1], StringUtils.EMPTY)));
+				return instant.plus(Integer.parseInt(addValue.replace(DURATION_UNIT[1], StringUtils.EMPTY)), ChronoUnit.MINUTES);
 			case 'h':
-				return DateUtils.addHours(date, Integer.parseInt(addValue.replace(DURATION_UNIT[2], StringUtils.EMPTY)));
+				return instant.plus(Integer.parseInt(addValue.replace(DURATION_UNIT[2], StringUtils.EMPTY)), ChronoUnit.HOURS);
 			case 'd':
-				return DateUtils.addDays(date, Integer.parseInt(addValue.replace(DURATION_UNIT[3], StringUtils.EMPTY)));
+				return instant.plus(Integer.parseInt(addValue.replace(DURATION_UNIT[3], StringUtils.EMPTY)), ChronoUnit.DAYS);
 			default:
 				throw new SwitcherInvalidDateTimeArgumentException(addValue);
 		}

--- a/src/test/java/com/switcherapi/client/utils/SwitcherUtilsTest.java
+++ b/src/test/java/com/switcherapi/client/utils/SwitcherUtilsTest.java
@@ -6,8 +6,6 @@ import com.switcherapi.client.exception.SwitcherContextException;
 import com.switcherapi.client.exception.SwitcherSnapshotLoadException;
 import com.switcherapi.client.model.ContextKey;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.time.DateFormatUtils;
-import org.apache.commons.lang3.time.DateUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -16,9 +14,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junitpioneer.jupiter.ClearEnvironmentVariable;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.nio.file.Paths;
-import java.text.ParseException;
-import java.util.Date;
 import java.util.Properties;
 import java.util.stream.Stream;
 
@@ -54,10 +54,14 @@ class SwitcherUtilsTest {
 				SwitcherContext::initializeClient);
 	}
 	
+	private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneOffset.UTC);
+	private static final String BASE_DATE = "2019-12-10 10:00:00";
+
 	@Test
-	void shouldReturnInvalidFormat() throws ParseException {
-		Date date1 = DateUtils.parseDate("2019-12-10 10:00:00", "yyyy-MM-dd HH:mm:ss");
-		assertThrows(Exception.class, () -> SwitcherUtils.addTimeDuration("1w", date1));
+	void shouldReturnInvalidFormat() {
+		Instant instant = LocalDateTime.parse(BASE_DATE, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+				.toInstant(ZoneOffset.UTC);
+		assertThrows(Exception.class, () -> SwitcherUtils.addTimeDuration("1w", instant));
 	}
 	
 	/**
@@ -77,10 +81,11 @@ class SwitcherUtilsTest {
 	
 	@ParameterizedTest()
 	@MethodSource("timeArguments")
-	void shouldAddTime(String time, String expectedValue) throws ParseException {
-		Date date1 = DateUtils.parseDate("2019-12-10 10:00:00", "yyyy-MM-dd HH:mm:ss");
-		date1 = SwitcherUtils.addTimeDuration(time, date1);
-		String dateString = DateFormatUtils.format(date1, "yyyy-MM-dd HH:mm:ss");
+	void shouldAddTime(String time, String expectedValue) {
+		Instant instant = LocalDateTime.parse(BASE_DATE, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+				.toInstant(ZoneOffset.UTC);
+		Instant result = SwitcherUtils.addTimeDuration(time, instant);
+		String dateString = DATE_FORMAT.format(result);
 		assertEquals(expectedValue, dateString);
 	}
 

--- a/src/test/java/com/switcherapi/fixture/MockWebServerHelper.java
+++ b/src/test/java/com/switcherapi/fixture/MockWebServerHelper.java
@@ -12,7 +12,7 @@ import mockwebserver3.MockWebServer;
 import mockwebserver3.QueueDispatcher;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -50,7 +50,7 @@ public class MockWebServerHelper {
     protected MockResponse generateMockAuth(int secondsAhead) {
         MockResponse.Builder builder = new MockResponse.Builder();
         builder.body(String.format("{ \"token\": \"%s\", \"exp\": \"%s\" }",
-                "mocked_token", SwitcherUtils.addTimeDuration(secondsAhead + "s", new Date()).getTime()/1000));
+                "mocked_token", SwitcherUtils.addTimeDuration(secondsAhead + "s", Instant.now()).getEpochSecond()));
         builder.addHeader("Content-Type", "application/json");
         return builder.build();
     }


### PR DESCRIPTION
This pull request modernizes date and time handling throughout the codebase by replacing legacy `Date` and `DateUtils` usage with Java 8+ time APIs (`Instant`, `LocalDateTime`, `DateTimeFormatter`, etc.). The changes improve code readability, reliability, and future-proof the code by leveraging the more robust and thread-safe Java time library. The updates also include corresponding changes in tests and utility methods.

The most important changes are:

**Migration to Java Time API:**

* Replaced all uses of `Date`, `SimpleDateFormat`, and `DateUtils` with `Instant`, `LocalDateTime`, and `DateTimeFormatter` in both production code and tests for date and time manipulation and parsing. [[1]](diffhunk://#diff-7c65cdea5f64f933d93793317683b73c719447a0ccbdec5211be8d8b955bade7L20-R20) [[2]](diffhunk://#diff-d219df774652a874673ecd3cd1540cac94759efdbe757dd455940fd49d9243d5L10-R18) [[3]](diffhunk://#diff-c439c4f6b45263c48c904498947970eea1f8028c6343bb32d5721d844f269d3eL10-R20) [[4]](diffhunk://#diff-fed76df3fcb1bb4519bf0e355422975e54285b8c02201a0c266c3a2d6001c0f7L10-R13) [[5]](diffhunk://#diff-be688195c45ef9318f96592489a1473900f5d26ead72c73f1a4467becb10e58fR17-L21) [[6]](diffhunk://#diff-72213fb909488410c0c40d567aba3b89b254eefafe6e5bbc15ca6d26ba93029aL15-R15)

**Core Utility and Service Updates:**

* Refactored `SwitcherUtils.addTimeDuration` to use `Instant` and `ChronoUnit` instead of `Date` and `DateUtils`, and updated all its usages accordingly. [[1]](diffhunk://#diff-fed76df3fcb1bb4519bf0e355422975e54285b8c02201a0c266c3a2d6001c0f7L31-R42) [[2]](diffhunk://#diff-7c65cdea5f64f933d93793317683b73c719447a0ccbdec5211be8d8b955bade7L150-R150) [[3]](diffhunk://#diff-72213fb909488410c0c40d567aba3b89b254eefafe6e5bbc15ca6d26ba93029aL53-R53)

**Validator Refactoring:**

* Updated `DateValidator` and `TimeValidator` to use `LocalDateTime` and `DateTimeFormatter`, including parsing, comparisons, and exception handling. This affects how date and time operations (e.g., LOWER, GREATER, BETWEEN) are implemented. [[1]](diffhunk://#diff-d219df774652a874673ecd3cd1540cac94759efdbe757dd455940fd49d9243d5L30-R58) [[2]](diffhunk://#diff-c439c4f6b45263c48c904498947970eea1f8028c6343bb32d5721d844f269d3eL30-R62)

**Test Suite Adjustments:**

* Refactored all affected tests to use the new Java time APIs, including updating test data setup, assertions, and helper methods in `SwitcherUtilsTest` and `MockWebServerHelper`. [[1]](diffhunk://#diff-be688195c45ef9318f96592489a1473900f5d26ead72c73f1a4467becb10e58fR57-R64) [[2]](diffhunk://#diff-be688195c45ef9318f96592489a1473900f5d26ead72c73f1a4467becb10e58fL80-R88) [[3]](diffhunk://#diff-72213fb909488410c0c40d567aba3b89b254eefafe6e5bbc15ca6d26ba93029aL53-R53)

**Dependency Cleanup:**

* Removed unnecessary imports for `DateUtils`, `SimpleDateFormat`, and related legacy date/time classes from all affected files. [[1]](diffhunk://#diff-7c65cdea5f64f933d93793317683b73c719447a0ccbdec5211be8d8b955bade7L20-R20) [[2]](diffhunk://#diff-d219df774652a874673ecd3cd1540cac94759efdbe757dd455940fd49d9243d5L10-R18) [[3]](diffhunk://#diff-c439c4f6b45263c48c904498947970eea1f8028c6343bb32d5721d844f269d3eL10-R20) [[4]](diffhunk://#diff-fed76df3fcb1bb4519bf0e355422975e54285b8c02201a0c266c3a2d6001c0f7L10-R13) [[5]](diffhunk://#diff-be688195c45ef9318f96592489a1473900f5d26ead72c73f1a4467becb10e58fL9-L10) [[6]](diffhunk://#diff-be688195c45ef9318f96592489a1473900f5d26ead72c73f1a4467becb10e58fR17-L21) [[7]](diffhunk://#diff-72213fb909488410c0c40d567aba3b89b254eefafe6e5bbc15ca6d26ba93029aL15-R15)