### PR TITLE
feat: enhanced performance when async (throttle) (#399)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>com.switcherapi</groupId>
 	<artifactId>switcher-client</artifactId>
 	<packaging>jar</packaging>
-	<version>1.10.0</version>
+	<version>1.10.1-SNAPSHOT</version>
 
 	<name>Switcher Client</name>
 	<description>Switcher Client SDK for working with Switcher API</description>
@@ -160,13 +160,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
-			<artifactId>okhttp</artifactId>
-			<version>${okhttp.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.squareup.okhttp3</groupId>
-			<artifactId>mockwebserver</artifactId>
+			<artifactId>mockwebserver3-junit5</artifactId>
 			<version>${okhttp.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/src/main/java/com/switcherapi/client/model/AsyncSwitcher.java
+++ b/src/main/java/com/switcherapi/client/model/AsyncSwitcher.java
@@ -31,7 +31,7 @@ public class AsyncSwitcher {
 	private long nextRun = 0;
 
 	public AsyncSwitcher(final Switcher switcher, long delay) {
-		this.executorService = Executors.newCachedThreadPool(r -> {
+		this.executorService = Executors.newSingleThreadExecutor(r -> {
 			Thread thread = new Thread(r);
 			thread.setName(SWITCHER_ASYNC_WORKER.toString());
 			thread.setDaemon(true);
@@ -47,14 +47,19 @@ public class AsyncSwitcher {
 	 * Switcher result for the Switcher executions map.
 	 */
 	public void execute() {
-		if (logger.isDebugEnabled()) {
-			SwitcherUtils.debug(logger, "nextRun: {} - currentTimeMillis: {}", nextRun, System.currentTimeMillis());
-		}
-		
-		if (nextRun < System.currentTimeMillis()) {
-			SwitcherUtils.debug(logger, "Running AsyncSwitcher");
+		final long currentTime = System.currentTimeMillis();
+		final boolean debugEnabled = logger.isDebugEnabled();
 
-			this.nextRun = System.currentTimeMillis() + this.delay;
+		if (debugEnabled) {
+			SwitcherUtils.debug(logger, "nextRun: {} - currentTimeMillis: {}", nextRun, currentTime);
+		}
+
+		if (nextRun < currentTime) {
+			if (debugEnabled) {
+				SwitcherUtils.debug(logger, "Running AsyncSwitcher");
+			}
+
+			this.nextRun = currentTime + this.delay;
 			this.executorService.submit(this::run);
 		}
 	}

--- a/src/main/java/com/switcherapi/client/model/SwitcherRequest.java
+++ b/src/main/java/com/switcherapi/client/model/SwitcherRequest.java
@@ -8,7 +8,7 @@ import com.switcherapi.client.test.SwitcherBypass;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -83,18 +83,19 @@ public final class SwitcherRequest extends SwitcherBuilder {
 
 	@Override
 	public SwitcherResult submit() throws SwitcherException {
-		if (SwitcherBypass.getBypass().containsKey(switcherKey)) {
-			return SwitcherBypass.getBypass().get(switcherKey).buildFromSwitcher(switcherKey, entry);
+		final Map<String, SwitcherResult> bypass = SwitcherBypass.getBypass();
+		if (!bypass.isEmpty() && bypass.containsKey(switcherKey)) {
+			return bypass.get(switcherKey).buildFromSwitcher(switcherKey, entry);
 		}
 
 		if (canUseAsync()) {
-			if (Objects.isNull(asyncSwitcher)) {
+			if (asyncSwitcher == null) {
 				asyncSwitcher = new AsyncSwitcher(this, super.delay);
 			}
 
 			asyncSwitcher.execute();
 			final SwitcherResult response = executionsMap.get(entry);
-			if (Objects.nonNull(response)) {
+			if (response != null) {
 				return response;
 			}
 		}


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the Switcher client. The main changes focus on dependency management, thread usage for async operations, and code simplification for better readability and performance.

**Dependency updates:**

* Updated the test dependency in `pom.xml` to use `mockwebserver3-junit5` instead of separate `okhttp` and `mockwebserver` dependencies, streamlining test dependencies.
* Bumped the project version in `pom.xml` from `1.10.0` to `1.10.1-SNAPSHOT` to reflect ongoing development.

**Async execution improvements:**

* Changed the executor in `AsyncSwitcher` from a cached thread pool to a single-threaded executor to avoid unnecessary thread creation and improve resource management.
* Refactored the `execute()` method in `AsyncSwitcher` to reduce redundant calls to `System.currentTimeMillis()` and improve logging clarity.

**Code simplification and cleanup:**

* Simplified null checks in `SwitcherRequest` by replacing `Objects.isNull`/`Objects.nonNull` with direct `null` comparisons, and improved bypass logic for clarity and efficiency. [[1]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L11-R11) [[2]](diffhunk://#diff-50b643c046fcf01d65f95fbeb497f0da0daaf755828ef185e1a3bd8381b2b710L86-R98)